### PR TITLE
Add test target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,4 @@
 build:
 	CGO_ENABLED=0 GO111MODULE=on go build -mod vendor -o _output/bin/cloud-network-config-controller cmd/cloud-network-config-controller/cloud-network-config-controller.go
+test:
+	go test ./...


### PR DESCRIPTION
I forgot to add a test target to the Makefile in the initial commit. This is needed as we'll need a test action when setting up the prow jobs in https://github.com/openshift/release/pull/15824 and have that CI be green. Once that PR merges and we get all the building blocks in place we can modify the test target to do something more sophisticated. 

/assign @squeed 