### PR TITLE
Add .ci-operator.yaml

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: rhel-8-release-golang-1.17-openshift-4.10


### PR DESCRIPTION
This adds a `.ci-operator.yaml` following the specification of such from https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image 

This is a precursor to having the bot automatically bump the test images defined at: https://github.com/openshift/release/blob/master/ci-operator/config/openshift/cloud-network-config-controller/openshift-cloud-network-config-controller-master.yaml#L11-L15 which will help when bumping vendored modules which require a go bump

/assign @danwinship   