### PR TITLE
Bug 2038840: Don't enqueue CloudPrivateIPConfig on delete

### DIFF
--- a/pkg/controller/cloudprivateipconfig/cloudprivateipconfig_controller.go
+++ b/pkg/controller/cloudprivateipconfig/cloudprivateipconfig_controller.go
@@ -161,6 +161,11 @@ func (c *CloudPrivateIPConfigController) SyncHandler(key string) error {
 	if err != nil {
 		return err
 	}
+	// When syncing objects which have been completely deleted: we must make
+	// sure to not continue processing the object.
+	if cloudPrivateIPConfig == nil {
+		return nil
+	}
 
 	ip := cloudPrivateIPConfigNameToIP(cloudPrivateIPConfig.Name)
 


### PR DESCRIPTION
On delete there is nothing for the cloud-private-ip-config controller
to do. If we are notified about a delete, we've clearly removed our
finalizer (or never got the time to add it in the first place) and we
have nothing to clean up. As it stands now we are enqueueing and
subsequently checking for if the object has been deleted from the API
server when syncing, but not dealing with the nil object which throws a
panic, as follows:

```
2021-12-20T07:51:51.482326344Z I1220 07:51:51.482306       1 controller.go:160] Dropping key '10.0.73.235' from the cloud-private-ip-config workqueue
2021-12-20T07:51:51.486331426Z I1220 07:51:51.486294       1 cloudprivateipconfig_controller.go:405] CloudPrivateIPConfig: "10.0.73.235" in work queue no longer exists
2021-12-20T07:51:51.486421234Z E1220 07:51:51.486395       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
2021-12-20T07:51:51.486421234Z goroutine 127 [running]:
2021-12-20T07:51:51.486421234Z k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1f7dca0, 0x3913df0})
2021-12-20T07:51:51.486421234Z  /go/src/github.com/openshift/cloud-network-config-controller/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x7d
2021-12-20T07:51:51.486421234Z k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0xc000714f90})
2021-12-20T07:51:51.486421234Z  /go/src/github.com/openshift/cloud-network-config-controller/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x75
2021-12-20T07:51:51.486421234Z panic({0x1f7dca0, 0x3913df0})
2021-12-20T07:51:51.486421234Z  /usr/lib/golang/src/runtime/panic.go:1038 +0x215
2021-12-20T07:51:51.486421234Z github.com/openshift/cloud-network-config-controller/pkg/controller/cloudprivateipconfig.(*CloudPrivateIPConfigController).SyncHandler(0xc0004be630, {0xc00072cfe0, 0xb})
2021-12-20T07:51:51.486421234Z  /go/src/github.com/openshift/cloud-network-config-controller/pkg/controller/cloudprivateipconfig/cloudprivateipconfig_controller.go:165 +0x57
2021-12-20T07:51:51.486421234Z github.com/openshift/cloud-network-config-controller/pkg/controller.(*CloudNetworkConfigController).processNextWorkItem.func1(0xc00081a120, {0x1db1440, 0xc000714f90})
2021-12-20T07:51:51.486421234Z  /go/src/github.com/openshift/cloud-network-config-controller/pkg/controller/controller.go:152 +0x126
2021-12-20T07:51:51.486421234Z github.com/openshift/cloud-network-config-controller/pkg/controller.(*CloudNetworkConfigController).processNextWorkItem(0xc00081a120)
2021-12-20T07:51:51.486421234Z  /go/src/github.com/openshift/cloud-network-config-controller/pkg/controller/controller.go:162 +0x46
2021-12-20T07:51:51.486421234Z github.com/openshift/cloud-network-config-controller/pkg/controller.(*CloudNetworkConfigController).runWorker(...)
2021-12-20T07:51:51.486421234Z  /go/src/github.com/openshift/cloud-network-config-controller/pkg/controller/controller.go:113
2021-12-20T07:51:51.486421234Z k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x7f639c55d9a0)
2021-12-20T07:51:51.486421234Z  /go/src/github.com/openshift/cloud-network-config-controller/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x67
2021-12-20T07:51:51.486421234Z k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x0, {0x26b4280, 0xc000767d70}, 0x1, 0xc0004fe4e0)
2021-12-20T07:51:51.486421234Z  /go/src/github.com/openshift/cloud-network-config-controller/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0xb6
2021-12-20T07:51:51.486421234Z k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x0, 0x3b9aca00, 0x0, 0x0, 0x0)
2021-12-20T07:51:51.486421234Z  /go/src/github.com/openshift/cloud-network-config-controller/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x89
2021-12-20T07:51:51.486421234Z k8s.io/apimachinery/pkg/util/wait.Until(0x0, 0x0, 0x0)

```

Signed-off-by: Alexander Constantinescu <aconstan@redhat.com>