### PR TITLE
Bug 2035093: AWS: Allow using auth methods other than static credentials

### DIFF
--- a/pkg/cloudprovider/aws.go
+++ b/pkg/cloudprovider/aws.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	awsapi "github.com/aws/aws-sdk-go/aws"
-	awscredentials "github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	ocpconfigv1 "github.com/openshift/api/config/v1"
@@ -29,16 +28,12 @@ type AWS struct {
 }
 
 func (a *AWS) initCredentials() error {
-	accessKey, err := a.readSecretData("aws_access_key_id")
-	if err != nil {
-		return err
+	sessionOpts := session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+		SharedConfigFiles: []string{cloudProviderSecretLocation + "credentials"},
 	}
-	secretKey, err := a.readSecretData("aws_secret_access_key")
-	if err != nil {
-		return err
-	}
-	mySession := session.Must(session.NewSession())
-	a.client = ec2.New(mySession, awsapi.NewConfig().WithCredentials(awscredentials.NewStaticCredentials(accessKey, secretKey, "")).WithRegion(a.region))
+	mySession := session.Must(session.NewSessionWithOptions(sessionOpts))
+	a.client = ec2.New(mySession, awsapi.NewConfig().WithRegion(a.region))
 	return nil
 }
 


### PR DESCRIPTION
This changes the AWS credentials loading to load the config file rather
than expecting static credentials files to be there. In the default case
of selfhosted OCP, this ends up doing the same as the config file
contains the static credentials but it will also work if a different
auth method like STS is defined. This allows the cncc to work in Hypershift.