### PR TITLE
Bug 2035167: fix cloudprivateipconfig sync on delete 

### DIFF
--- a/pkg/controller/cloudprivateipconfig/cloudprivateipconfig_controller.go
+++ b/pkg/controller/cloudprivateipconfig/cloudprivateipconfig_controller.go
@@ -142,10 +142,10 @@ func NewCloudPrivateIPConfigController(
 // that the IP is already assigned
 
 // - DELETE:
-// 1. Set status.conditions[0].Status = Pending (unset status.node)
+// 1. Set status.conditions[0].Status = Pending
 // 2. Send cloud API DELETE request
 // ...some time later
-// *	If OK: -
+// *	If OK: unset status.node
 // * 	If !OK: set status.node = spec.node and status.conditions[0].Status = Error && goto 1. by resync
 
 // - UPDATE:
@@ -186,6 +186,7 @@ func (c *CloudPrivateIPConfigController) SyncHandler(key string) error {
 		// This is step 2. in the docbloc for the DELETE operation in the
 		// syncHandler
 		status = &cloudnetworkv1.CloudPrivateIPConfigStatus{
+			Node: nodeToDel,
 			Conditions: []metav1.Condition{
 				{
 					Type:               string(cloudnetworkv1.Assigned),
@@ -264,7 +265,7 @@ func (c *CloudPrivateIPConfigController) SyncHandler(key string) error {
 		// This is step 2. in the docbloc for the ADD operation in the
 		// syncHandler
 		status = &cloudnetworkv1.CloudPrivateIPConfigStatus{
-			Node: cloudPrivateIPConfig.Spec.Node,
+			Node: nodeToAdd,
 			Conditions: []metav1.Condition{
 				{
 					Type:               string(cloudnetworkv1.Assigned),
@@ -308,6 +309,7 @@ func (c *CloudPrivateIPConfigController) SyncHandler(key string) error {
 			// If we couldn't even execute the assign request, set the status to
 			// failed.
 			status = &cloudnetworkv1.CloudPrivateIPConfigStatus{
+				Node: nodeToAdd,
 				Conditions: []metav1.Condition{
 					{
 						Type:               string(cloudnetworkv1.Assigned),
@@ -328,7 +330,7 @@ func (c *CloudPrivateIPConfigController) SyncHandler(key string) error {
 		// Add occurred and no error was encountered, keep status.node from
 		// above
 		status = &cloudnetworkv1.CloudPrivateIPConfigStatus{
-			Node: cloudPrivateIPConfig.Status.Node,
+			Node: nodeToAdd,
 			Conditions: []metav1.Condition{
 				{
 					Type:               string(cloudnetworkv1.Assigned),

--- a/pkg/controller/cloudprivateipconfig/cloudprivateipconfig_controller_test.go
+++ b/pkg/controller/cloudprivateipconfig/cloudprivateipconfig_controller_test.go
@@ -212,6 +212,7 @@ func TestSyncAddCloudPrivateIPConfig(t *testing.T) {
 					Node: nodeNameA,
 				},
 				Status: cloudnetworkv1.CloudPrivateIPConfigStatus{
+					Node: nodeNameA,
 					Conditions: []v1.Condition{
 						{
 							Type:   string(cloudnetworkv1.Assigned),
@@ -248,6 +249,7 @@ func TestSyncAddCloudPrivateIPConfig(t *testing.T) {
 					Node: nodeNameA,
 				},
 				Status: cloudnetworkv1.CloudPrivateIPConfigStatus{
+					Node: nodeNameA,
 					Conditions: []v1.Condition{
 						{
 							Type:   string(cloudnetworkv1.Assigned),
@@ -398,6 +400,7 @@ func TestSyncAddCloudPrivateIPConfig(t *testing.T) {
 					Node: nodeNameA,
 				},
 				Status: cloudnetworkv1.CloudPrivateIPConfigStatus{
+					Node: nodeNameA,
 					Conditions: []v1.Condition{
 						{
 							Type:   string(cloudnetworkv1.Assigned),
@@ -454,6 +457,7 @@ func TestSyncAddCloudPrivateIPConfig(t *testing.T) {
 					Node: nodeNameA,
 				},
 				Status: cloudnetworkv1.CloudPrivateIPConfigStatus{
+					Node: nodeNameA,
 					Conditions: []v1.Condition{
 						{
 							Type:   string(cloudnetworkv1.Assigned),
@@ -556,6 +560,7 @@ func TestSyncDeleteCloudPrivateIPConfig(t *testing.T) {
 					Node: nodeNameA,
 				},
 				Status: cloudnetworkv1.CloudPrivateIPConfigStatus{
+					Node: nodeNameA,
 					Conditions: []v1.Condition{
 						{
 							Type:   string(cloudnetworkv1.Assigned),
@@ -708,6 +713,7 @@ func TestSyncDeleteCloudPrivateIPConfig(t *testing.T) {
 					Node: nodeNameA,
 				},
 				Status: cloudnetworkv1.CloudPrivateIPConfigStatus{
+					Node: nodeNameA,
 					Conditions: []v1.Condition{
 						{
 							Type:   string(cloudnetworkv1.Assigned),
@@ -1017,6 +1023,7 @@ func TestSyncUpdateCloudPrivateIPConfig(t *testing.T) {
 					Node: nodeNameB,
 				},
 				Status: cloudnetworkv1.CloudPrivateIPConfigStatus{
+					Node: nodeNameB,
 					Conditions: []v1.Condition{
 						{
 							Type:   string(cloudnetworkv1.Assigned),


### PR DESCRIPTION
This PR fixes an issue experienced while processing deletes whereby in certain corner cases we could end up with a failed cloud release but a successful status update just before. The status update unset the `.status.node` field so on any succeeding sync we never retried the delete again, leading to an un-reconcilable state. 

It also fixes a spurious issue during adds, namely: if  `AssignPrivateIP` fails we unset the node in the status, this caused additional en-queuing of the same object by our `UpdateFunc`. If `AssignPrivateIP` fails we will still re-sync the object and re-attempt the add (since the `.status.conditions[0].status != True`), doing this however avoids both erroneously enqueuing the object and confusing logs.  

It also attempts improving the log message as to make them easier to discern when reading the logs, as well as using `getCloudPrivateIPConfig` when updating the CloudPrivateIPConfig during our sync (and hence using one context per call). 

/assign @danwinship 