### PR TITLE
Bug 2041882: gcp: retrieve project from resources, not from the credentials

### DIFF
--- a/pkg/cloudprovider/gcp_test.go
+++ b/pkg/cloudprovider/gcp_test.go
@@ -1,0 +1,31 @@
+package cloudprovider
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestSplitGCPNode(t *testing.T) {
+	n := corev1.Node{
+		Spec: corev1.NodeSpec{
+			ProviderID: "gce://openshift-qe/us-central1-a/lwanstsg0118f-tvpsk-master-0",
+		},
+	}
+
+	project, zone, instance, err := splitGCPNode(&n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if project != "openshift-qe" {
+		t.Fatalf("wrong project: %s", project)
+	}
+
+	if zone != "us-central1-a" {
+		t.Fatalf("wrong zone: %s", zone)
+	}
+
+	if instance != "lwanstsg0118f-tvpsk-master-0" {
+		t.Fatalf("wrong name: %s", instance)
+	}
+}


### PR DESCRIPTION
It turns out that GCP, when in "workload identity" mode, doesn't provide the project in the credentials file. The  easy fix: extract it from the node objects themselves.