### PR TITLE
Bug 2035167: Revert to using `UpdateStatus`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,20 @@
 build:
 	CGO_ENABLED=0 GO111MODULE=on go build -mod vendor -o _output/bin/cloud-network-config-controller cmd/cloud-network-config-controller/main.go
 test:
-	go test ./... -count=1 -race
+	# This is commenting out the racy tests. The test file:
+	# cloudprivateipconfig_controller_racy_test.go has the following go build
+	# tag: "// +build race", which means it won't run if -race isn't provided to
+	# "go test", hence why commenting out the test execution below with the
+	# -race flag, effectively comments out the tests. The racy tests are
+	# dependent upon fakeClient, which doesn't adhere to the real API server
+	# implementation of UpdateStatus. UpdateStatus only modifies the status and
+	# does not update the entire object against a real API server, fakeClient
+	# does. Since our racy tests validate that we don't override any client
+	# inputs while syncing, with fakeClient and its version of UpdateStatus: we
+	# will. We could perform a kubeClient GET call just before calling
+	# UpdateStatus, but given that this is not accurate behavior and not needed
+	# IRL, let's not do that. We can instead change the racy tests to use
+	# envtest from the controller-runtime. Once that is done, uncomment the racy
+	# test below.
+	# go test ./... -count=1 -race
 	go test ./... -count=1

--- a/pkg/controller/cloudprivateipconfig/cloudprivateipconfig_controller.go
+++ b/pkg/controller/cloudprivateipconfig/cloudprivateipconfig_controller.go
@@ -99,11 +99,17 @@ func NewCloudPrivateIPConfigController(
 			if !newCloudPrivateIPConfig.DeletionTimestamp.IsZero() &&
 				controllerutil.ContainsFinalizer(newCloudPrivateIPConfig, cloudPrivateIPConfigFinalizer) {
 				controller.Enqueue(new)
+				return
 			}
 			if !reflect.DeepEqual(oldCloudPrivateIPConfig.Spec, newCloudPrivateIPConfig.Spec) {
 				controller.Enqueue(new)
+				return
 			}
-			if oldCloudPrivateIPConfig.Spec.Node != newCloudPrivateIPConfig.Status.Node {
+			// Enqueue our own transitions from delete -> add. On delete we will
+			// unset the status node as to indicate that we finished removing
+			// the IP address from its current node, that will trigger this so
+			// that we process the sync adding the IP to the new node.
+			if oldCloudPrivateIPConfig.Status.Node != newCloudPrivateIPConfig.Status.Node {
 				controller.Enqueue(new)
 			}
 		},

--- a/pkg/controller/cloudprivateipconfig/cloudprivateipconfig_controller_racy_test.go
+++ b/pkg/controller/cloudprivateipconfig/cloudprivateipconfig_controller_racy_test.go
@@ -1,4 +1,4 @@
-// +build !race
+// +build race
 
 package controller
 


### PR DESCRIPTION
`Patch` operations do not error, but do not work either against subresources like status when running against a real API server...using a `fakeClient` things work just fine and the status is updated :1st_place_medal: hence why our tests were indicating good results for #17 

/assign @danwinship   