### PR TITLE
Bug 2060361: Fix Unable to enumerate NICs due to a missing 'primary' field due to security restrictions

### DIFF
--- a/pkg/cloudprovider/azure.go
+++ b/pkg/cloudprovider/azure.go
@@ -279,16 +279,6 @@ func (a *Azure) getNetworkInterfaces(instance *compute.VirtualMachine) ([]networ
 		return nil, NoNetworkInterfaceError
 	}
 	networkInterfaces := []network.Interface{}
-	// When the VM has only a single NIC, don't rely on the presence of the Primary field, which is populated by
-	// NetworkInterfaceReferenceProperties, because it is not populated in some cases due to security restrictions
-	if len(*instance.NetworkProfile.NetworkInterfaces) == 1 {
-		intf, err := a.getNetworkInterface(*(*instance.NetworkProfile.NetworkInterfaces)[0].ID)
-		if err != nil {
-			return nil, err
-		}
-		networkInterfaces = append(networkInterfaces, intf)
-		return networkInterfaces, nil
-	}
 	// Try to get the ID corresponding to the "primary" NIC and put that first
 	// in the slice. Do it like this because it's assumed to not be guaranteed
 	// to be first in the slice returned by the Azure API?
@@ -313,6 +303,16 @@ func (a *Azure) getNetworkInterfaces(instance *compute.VirtualMachine) ([]networ
 		}
 	}
 	if len(networkInterfaces) == 0 {
+		// Due to security restrictions access, the NIC's "primary" field is not enumerable.
+		// If we have NICs, then select the first in the list.
+		if len(*instance.NetworkProfile.NetworkInterfaces) > 0 {
+			intf, err := a.getNetworkInterface(*(*instance.NetworkProfile.NetworkInterfaces)[0].ID)
+			if err != nil {
+				return nil, err
+			}
+			networkInterfaces = append(networkInterfaces, intf)
+			return networkInterfaces, nil
+		}
 		return nil, NoNetworkInterfaceError
 	}
 	return networkInterfaces, nil


### PR DESCRIPTION
If the security settings on a NIC prevent the enumeration of the NetworkInterfaceReferenceProperties to populate Primary field, then the NIC is not processed, leading to the 'cloud.network.openshift.io/egress-ipconfig' annotation not being applied to a node.

In order to overcome this limitation, this PR contains 2 commits to address the issues we are seeing on master VM nodes in ARO.

**Option 1** (commit e9a46a0): Does not rely on the Primary field being present to select the NIC, because there is only one to choose from.
**Option 2** (commit d9ddd33): Selects the first NIC in the list when the lookup based on the primary field has failed. This will have no side effects for VMs with only a single NIC, which is what we have in ARO. However, in multi-NIC scenarios it is a compromise since we do not _really_ know which one we should be picking.

At the very least we should go with the first commit in this PR to address the permissions issue on master nodes in ARO clusters, but either would work.