### PR TITLE
Bug 2071914: azure: default empty environment to AzurePublicCloud

### DIFF
--- a/cmd/cloud-network-config-controller/main.go
+++ b/cmd/cloud-network-config-controller/main.go
@@ -93,7 +93,7 @@ func main() {
 
 				cloudProviderClient, err := cloudprovider.NewCloudProviderClient(platformCfg)
 				if err != nil {
-					klog.Fatal("Error building cloud provider client, err: %v", err)
+					klog.Fatalf("Error building cloud provider client, err: %v", err)
 				}
 
 				kubeInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(kubeClient, time.Minute*2, kubeinformers.WithNamespace(controllerNamespace))

--- a/pkg/cloudprovider/azure.go
+++ b/pkg/cloudprovider/azure.go
@@ -64,7 +64,11 @@ func (a *Azure) initCredentials() error {
 	if a.cfg.APIOverride != "" {
 		a.env, err = azure.EnvironmentFromURL(a.cfg.APIOverride)
 	} else {
-		a.env, err = azure.EnvironmentFromName(a.cfg.AzureEnvironment)
+		name := a.cfg.AzureEnvironment
+		if name == "" {
+			name = "AzurePublicCloud"
+		}
+		a.env, err = azure.EnvironmentFromName(name)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to initialize Azure environment: %w", err)


### PR DESCRIPTION
Annoyingly, the CNO does a silly thing and explicitly passes an empty string. Doh. So, work around that.

/cc @andreaskaris 