### PR TITLE
Bug 2111878: Make azure operations to be in sequence

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"path/filepath"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -123,6 +124,7 @@ func NewCloudProviderClient(cfg CloudProviderConfig) (CloudProviderIntf, error) 
 	case PlatformTypeAzure:
 		cloudProviderIntf = &Azure{
 			CloudProvider: cp,
+			nodeLockMap:   make(map[string]*sync.Mutex),
 		}
 	case PlatformTypeAWS:
 		cloudProviderIntf = &AWS{


### PR DESCRIPTION
When an operation is in progress on the azure, performing another
operation is not allowed and further attempts made to fail until
event thread gives up (because previous op takes too long if op
type is delete) on new operation. Hence this serializes assign
and release operations on the azure client.

Signed-off-by: Periyasamy Palanisamy <pepalani@redhat.com>