### PR TITLE
Bug 2118563: Adjust OpenStack port capacity to default max_allowed_address_pair

### DIFF
--- a/pkg/cloudprovider/openstack_test.go
+++ b/pkg/cloudprovider/openstack_test.go
@@ -627,8 +627,7 @@ func TestOpenStackPlugin(t *testing.T) {
 				IPv6: "2000::/64",
 			},
 			Capacity: capacity{
-				IPv4: 63, // Ceiling of 64 - 1 allocated ports on the subnet.
-				IPv6: 63, // Ceiling of 64 - 1 allocated ports on the subnet.
+				IP: openstackMaxCapacity,
 			},
 		},
 		{
@@ -638,8 +637,7 @@ func TestOpenStackPlugin(t *testing.T) {
 				IPv6: "2001::/64",
 			},
 			Capacity: capacity{
-				IPv4: 63, // Ceiling of 64 - 1 allocated ports on the subnet.
-				IPv6: 63, // Ceiling of 64 - 1 allocated ports on the subnet.
+				IP: openstackMaxCapacity,
 			},
 		},
 	}
@@ -731,8 +729,7 @@ func TestGetNeutronPortNodeEgressIPConfiguration(t *testing.T) {
 					IPv6: "2000::/64",
 				},
 				Capacity: capacity{
-					IPv4: openstackMaxCapacity - 3, // Max capacity - 1 fixed IP - 2 allocated IPs.
-					IPv6: openstackMaxCapacity - 1, // Max capacity - 1 fixed IP.
+					IP: openstackMaxCapacity - 2, // 2 allowed_address_pairs configured on the port.
 				},
 			},
 		},
@@ -745,8 +742,7 @@ func TestGetNeutronPortNodeEgressIPConfiguration(t *testing.T) {
 					IPv6: "2000::/64",
 				},
 				Capacity: capacity{
-					IPv4: openstackMaxCapacity - 3, // Ceiling - 1 fixed IP - 2 allocated IPs.
-					IPv6: openstackMaxCapacity - 1, // Ceiling - 1 fixed IP.
+					IP: openstackMaxCapacity - 2, // 2 allowed_address_pairs configured on the port.
 				},
 			},
 		},


### PR DESCRIPTION
The default max_allowed_address_pair is 10. That value cannot be
retrieved via the API so we must make a best guess here and set this to
the default.

Cause: 
The CloudNetworkConfigController (CNCC) used a hardcoded capacity of 64 which is above OpenStack's default max_allowed_address_pairs count of 10.

Consequence: 
Capacity was misreported and the EgressIP controller created CloudPrivateIPConfig objects beyond OpenStack's capacity. The CloudPrivateIPConfig objects would error out with "The number of allowed address pair exceeds the maximum 10"

Fix: 
The default max_allowed_address_pair for RHOSP is 10. Unfortunately, this value cannot be
retrieved via any API requests. It is solely exposed through neutron's configuration files. As a heuristic, the CNCC now assumes that all OSP environments set this to 10. As a consequence, any OSP environment that shall be used together with Red Hat OpenShift Container Platform and the EgressIP feature must have max_allowed_address_pairs set to 10 or above in neutron's configuration.

Result: 
Port capacity is now capped at 10 minus the number of allowed_address_pairs.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>