### PR TITLE
Jira OCPBUGS-208: OpenStack: Avoid concurrent port updates for attach/detach operations

### DIFF
--- a/pkg/cloudprovider/openstack.go
+++ b/pkg/cloudprovider/openstack.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/google/uuid"
 	"github.com/gophercloud/gophercloud"
@@ -52,8 +53,10 @@ const (
 // to the OpenStack API
 type OpenStack struct {
 	CloudProvider
-	novaClient    *gophercloud.ServiceClient
-	neutronClient *gophercloud.ServiceClient
+	novaClient       *gophercloud.ServiceClient
+	neutronClient    *gophercloud.ServiceClient
+	portLockMapMutex sync.Mutex
+	portLockMap      map[string]*sync.Mutex
 }
 
 // initCredentials initializes the cloud API credentials by reading the
@@ -634,6 +637,12 @@ func (o *OpenStack) getNeutronPortWithIPAddressAndMachineID(s neutronsubnets.Sub
 
 // allowIPAddressOnNeutronPort adds the specified IP address to the port's allowed_address_pairs.
 func (o *OpenStack) allowIPAddressOnNeutronPort(portID string, ip net.IP) error {
+	// Needed due to neutron bug  https://bugzilla.redhat.com/show_bug.cgi?id=2119199.
+	klog.Info("Getting port lock for portID %s and IP %s", portID, ip.String())
+	portLock := o.getLockForPort(portID)
+	portLock.Lock()
+	defer portLock.Unlock()
+
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// Always get the most recent copy of this port.
 		p, err := neutronports.Get(o.neutronClient, portID).Extract()
@@ -682,6 +691,12 @@ func (o *OpenStack) allowIPAddressOnNeutronPort(portID string, ip net.IP) error 
 
 // unallowIPAddressOnNeutronPort removes the specified IP address from the port's allowed_address_pairs.
 func (o *OpenStack) unallowIPAddressOnNeutronPort(portID string, ip net.IP) error {
+	// Needed due to neutron bug  https://bugzilla.redhat.com/show_bug.cgi?id=2119199.
+	klog.Info("Getting port lock for portID %s and IP %s", portID, ip.String())
+	portLock := o.getLockForPort(portID)
+	portLock.Lock()
+	defer portLock.Unlock()
+
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// Always get the most recent copy of this port.
 		p, err := neutronports.Get(o.neutronClient, portID).Extract()
@@ -823,4 +838,18 @@ func getNovaServerIDFromProviderID(providerID string) (string, error) {
 // generateDeviceID is a tiny helper to allow us to work around https://bugzilla.redhat.com/show_bug.cgi?id=2109162.
 func generateDeviceID(serverID string) string {
 	return fmt.Sprintf("%s_%s", egressIPTag, serverID)
+}
+
+// getLockForPort returns a sync.Mutex for port with portID.
+func (o *OpenStack) getLockForPort(portID string) *sync.Mutex {
+	o.portLockMapMutex.Lock()
+	defer o.portLockMapMutex.Unlock()
+
+	if o.portLockMap == nil {
+		o.portLockMap = make(map[string]*sync.Mutex)
+	}
+	if _, ok := o.portLockMap[portID]; !ok {
+		o.portLockMap[portID] = &sync.Mutex{}
+	}
+	return o.portLockMap[portID]
 }


### PR DESCRIPTION
Due to issue https://bugzilla.redhat.com/show_bug.cgi?id=2119199 in
neutron, we cannot rely on the revision_number checks that OSP provides.
Instead, we must implement our own per-port locking mechanism so that
concurrent updates become impossible.

This follows the same approach as the Azure fix in commit
https://github.com/openshift/cloud-network-config-controller/commit/3c2cb5063d7a1a9d60e48c6a48b4a42eab5da688.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>
Reported-at: https://issues.redhat.com/browse/OCPBUGS-208