### PR TITLE
Jira OCPBUGS-247: OpenStack Return UnexpectedURIError when URI cannot be parsed

### DIFF
--- a/pkg/cloudprovider/openstack.go
+++ b/pkg/cloudprovider/openstack.go
@@ -814,8 +814,13 @@ func isIPAddressAllowedOnNeutronPort(p neutronports.Port, ip net.IP) bool {
 // getNovaServerIDFromProviderID extracts the nova server ID from the given providerID.
 func getNovaServerIDFromProviderID(providerID string) (string, error) {
 	serverID := strings.TrimPrefix(providerID, openstackProviderPrefix)
+	if serverID == providerID {
+		return "", UnexpectedURIError(fmt.Sprintf("%s; the provider ID does not contain expected prefix %s",
+			providerID, openstackProviderPrefix))
+	}
 	if _, err := uuid.Parse(serverID); err != nil {
-		return "", fmt.Errorf("cannot parse valid nova server ID from providerId '%s'", providerID)
+		return "", UnexpectedURIError(fmt.Sprintf("%s; error parsing UUID %q: %q",
+			providerID, serverID, err.Error()))
 	}
 	return serverID, nil
 }

--- a/pkg/cloudprovider/openstack_test.go
+++ b/pkg/cloudprovider/openstack_test.go
@@ -1257,12 +1257,14 @@ func TestGetNovaServerIDFromProviderID(t *testing.T) {
 			output: "91dcacbf-fa2a-40c8-a194-c3a51ab57062",
 		},
 		{
-			input:     "openstack://91dcacbf-fa2a-40c8-a194-c3a51ab57062",
-			errString: "cannot parse valid nova server ID from providerId 'openstack://91dcacbf-fa2a-40c8-a194-c3a51ab57062'",
+			input: "openstack://91dcacbf-fa2a-40c8-a194-c3a51ab57062",
+			errString: "the URI is not expected: openstack://91dcacbf-fa2a-40c8-a194-c3a51ab57062; " +
+				"the provider ID does not contain expected prefix openstack:///",
 		},
 		{
-			input:     "openstack:///91dcacbf-fa2a-40c8-a194-c3a51ab5706",
-			errString: "cannot parse valid nova server ID from providerId 'openstack:///91dcacbf-fa2a-40c8-a194-c3a51ab5706'",
+			input: "openstack:///91dcacbf-fa2a-40c8-a194-c3a51ab5706",
+			errString: "the URI is not expected: openstack:///91dcacbf-fa2a-40c8-a194-c3a51ab5706; " +
+				"error parsing UUID \"91dcacbf-fa2a-40c8-a194-c3a51ab5706\": \"invalid UUID length: 35\"",
 		},
 	}
 


### PR DESCRIPTION
All other cloud types report UnexpectedURIError, so do the same.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>