### PR TITLE
OCPBUGS-1629: Add resolver to handle custom endpoints

### DIFF
--- a/pkg/cloudprovider/aws.go
+++ b/pkg/cloudprovider/aws.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	awsapi "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	corev1 "k8s.io/api/core/v1"
@@ -32,10 +33,19 @@ func (a *AWS) initCredentials() error {
 	sessionOpts := session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 		SharedConfigFiles: []string{filepath.Join(a.cfg.CredentialDir, "credentials")},
+		Config:            awsapi.Config{Region: &a.cfg.Region},
 	}
-	c := awsapi.NewConfig().WithRegion(a.cfg.Region)
 	if a.cfg.APIOverride != "" {
-		c = c.WithEndpoint(a.cfg.APIOverride)
+		customResolver := func(service, region string, optFns ...func(*endpoints.Options)) (endpoints.ResolvedEndpoint, error) {
+			if service == endpoints.Ec2ServiceID {
+				return endpoints.ResolvedEndpoint{
+					URL:           a.cfg.APIOverride,
+					SigningRegion: a.cfg.Region,
+				}, nil
+			}
+			return endpoints.DefaultResolver().EndpointFor(service, region, optFns...)
+		}
+		sessionOpts.Config.EndpointResolver = endpoints.ResolverFunc(customResolver)
 	}
 	if a.cfg.AWSCAOverride != "" {
 		var err error
@@ -50,7 +60,7 @@ func (a *AWS) initCredentials() error {
 		return fmt.Errorf("could not initialize AWS session: %w", err)
 	}
 
-	a.client = ec2.New(mySession, c)
+	a.client = ec2.New(mySession)
 	return nil
 }
 


### PR DESCRIPTION
Based on https://github.com/openshift/cloud-network-config-controller/pull/60

CNO sets `platform-api-url param`(`APIOverride`) to ec2 service endpoint https://github.com/openshift/cluster-network-operator/blob/e1d349aa0f2c1282bfb5ab843efe1f0501b2a9e2/pkg/network/cloud_network.go#L49
We should only use that endpoint for EC2 service.

This patch adds a custom resolver to only set a custom endpoint on EC2 service.

/assign @andreaskaris 

(cherry picked from commit 489c81d07e4bd5fbe93fd400cb27def4ab0ef70d)
Signed-off-by: Patryk Diak <pdiak@redhat.com>