### PR TITLE
OCPBUGS-1736: use proxy vars when available

### DIFF
--- a/pkg/cloudprovider/openstack.go
+++ b/pkg/cloudprovider/openstack.go
@@ -126,6 +126,7 @@ func (o *OpenStack) initCredentials() error {
 		transport := http.Transport{}
 		certPool.AppendCertsFromPEM([]byte(userCACert))
 		transport.TLSClientConfig = &tls.Config{RootCAs: certPool}
+		transport.Proxy = http.ProxyFromEnvironment
 		provider.HTTPClient = http.Client{Transport: &transport}
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("could not parse file '%s', err: %q", caBundle, err)


### PR DESCRIPTION
When set, the proxy variables will be now used by the controller to
reach OpenStack through the proxy and not directly.

Bug OCPBUGS-1736
