### PR TITLE
Update .ci-operator.yaml to use go 1.19

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.12
+  tag: rhel-8-release-golang-1.19-openshift-4.12


### PR DESCRIPTION
Signed-off-by: Patryk Diak <pdiak@redhat.com>