### PR TITLE
OCPBUGS-1417: AWS: build temp credentials file from AWS key and secret

### DIFF
--- a/pkg/cloudprovider/aws_test.go
+++ b/pkg/cloudprovider/aws_test.go
@@ -1,6 +1,10 @@
 package cloudprovider
 
 import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
 	"testing"
 )
 
@@ -67,6 +71,78 @@ func TestGetInstanceIdFromProviderId(t *testing.T) {
 					t.Fatalf("Expected output %s but got output %s instead", tc.output, out)
 				}
 			}
+		}
+	}
+}
+
+func TestSharedCredentialsFileFromDirectory(t *testing.T) {
+	tcs := []struct {
+		files     map[string]string
+		fExpected string
+		expected  string
+		err       string
+	}{
+		{
+			files: map[string]string{
+				"credentials":           "content-of-credentials",
+				"aws_access_key_id":     "content-of-access-key-id",
+				"aws_secret_access_key": "content-of-secret-access-key",
+			},
+			expected: "content-of-credentials",
+		},
+		{
+			files: map[string]string{
+				"credentials": "content-of-credentials",
+			},
+			expected: "content-of-credentials",
+		},
+		{
+			files: map[string]string{
+				"aws_access_key_id":     "content-of-access-key-id",
+				"aws_secret_access_key": "content-of-secret-access-key",
+			},
+			expected: fmt.Sprintf("[default]\naws_access_key_id = %s\naws_secret_access_key = %s\n",
+				"content-of-access-key-id", "content-of-secret-access-key"),
+		},
+		{
+			files: map[string]string{
+				"aws_secret_access_key": "content-of-secret-access-key",
+			},
+			err: "aws_access_key_id: no such file or directory",
+		},
+	}
+
+	for i, tc := range tcs {
+		tmpdir := t.TempDir()
+		for fileName, fileContent := range tc.files {
+			err := os.WriteFile(path.Join(tmpdir, fileName), []byte(fileContent), 0644)
+			if err != nil {
+				t.Fatalf("TestSharedCredentialsFileFromDirectory (%d): Unexpected error creating file %s, err: %q",
+					i, fileName, err)
+			}
+		}
+		fExpected, err := sharedCredentialsFileFromDirectory(tmpdir)
+		// Handle error testing.
+		if tc.err != "" {
+			if err == nil || !strings.Contains(err.Error(), tc.err) {
+				t.Fatalf("TestSharedCredentialsFileFromDirectory (%d): Expected to get error with substring %q but got %q instead",
+					i, tc.err, err)
+			}
+			continue
+		}
+		// Handle when no error should occur.
+		if err != nil {
+			t.Fatalf("TestSharedCredentialsFileFromDirectory (%d): Unexpected error from sharedCredentialsFileFromDirectory, err: %q",
+				i, err)
+		}
+		expected, err := os.ReadFile(fExpected)
+		if err != nil {
+			t.Fatalf("TestSharedCredentialsFileFromDirectory (%d): Unexpected error reading expected file %s, err: %q",
+				i, fExpected, err)
+		}
+		if string(expected) != tc.expected {
+			t.Fatalf("TestSharedCredentialsFileFromDirectory (%d): Unexpected content, want %q but have %q",
+				i, tc.expected, string(expected))
 		}
 	}
 }


### PR DESCRIPTION
If file credentials cannot be found then build a temp file from aws_access_key_id and aws_secret_access_key.
Other operators build AWS credentials from aws_access_key_id and aws_secret_access_key without the need to have an explicit credentials file. This is not a problem for environments where the cloud-credential-operator injects the correct data. However, in manual credentials mode, users seem to expect to only provide the key_id and access_key.

Reported-at: https://issues.redhat.com/browse/OCPBUGS-1417
Signed-off-by: Andreas Karis <ak.karis@gmail.com>