### PR TITLE
Fix azure log message for assigning and releasing an IP

### DIFF
--- a/pkg/cloudprovider/aws.go
+++ b/pkg/cloudprovider/aws.go
@@ -357,10 +357,12 @@ func (a *AWS) getInstance(node *corev1.Node) (*ec2.Instance, error) {
 // But it might also be passed in as aws://<zone>/<instanceID> and the zone might
 // be omitted.
 // This is what the node's providerID can look like on AWS (examples):
-//    spec:
-//      providerID: aws:///us-west-2a/i-008447f243eead273
-//      providerID: aws://us-west-2a/i-008447f243eead273
-//      providerID: aws:///i-008447f243eead273
+//
+//	spec:
+//	  providerID: aws:///us-west-2a/i-008447f243eead273
+//	  providerID: aws://us-west-2a/i-008447f243eead273
+//	  providerID: aws:///i-008447f243eead273
+//
 // see https://github.com/kubernetes/cloud-provider-aws/blob/5f394ba297bf280ceb3edfc38922630b4bd83f46/pkg/providers/v2/instances.go#L254
 func getInstanceIdFromProviderId(providerId string) (string, error) {
 	// after trimming 'aws://', the remainder will be in one of the following formats:

--- a/pkg/cloudprovider/azure.go
+++ b/pkg/cloudprovider/azure.go
@@ -99,7 +99,7 @@ func (a *Azure) initCredentials() error {
 
 func (a *Azure) AssignPrivateIP(ip net.IP, node *corev1.Node) error {
 	ipc := ip.String()
-	klog.Info("acquiring node lock for assigning ip address, node: %s, ip: %s", node.Name, ipc)
+	klog.Infof("Acquiring node lock for assigning ip address, node: %s, ip: %s", node.Name, ipc)
 	nodeLock := a.getNodeLock(node.Name)
 	nodeLock.Lock()
 	defer nodeLock.Unlock()
@@ -140,7 +140,7 @@ func (a *Azure) AssignPrivateIP(ip net.IP, node *corev1.Node) error {
 }
 
 func (a *Azure) ReleasePrivateIP(ip net.IP, node *corev1.Node) error {
-	klog.Info("acquiring node lock for releasing ip address, node: %s, ip: %s", node.Name, ip.String())
+	klog.Infof("Acquiring node lock for releasing ip address, node: %s, ip: %s", node.Name, ip.String())
 	nodeLock := a.getNodeLock(node.Name)
 	nodeLock.Lock()
 	defer nodeLock.Unlock()

--- a/pkg/cloudprovider/azure.go
+++ b/pkg/cloudprovider/azure.go
@@ -269,7 +269,9 @@ func (a *Azure) getCapacity(networkInterface network.Interface) int {
 
 // This is what the node's providerID looks like on Azure
 // spec:
-//   providerID: azure:///subscriptions/ee2e2172-e246-4d4b-a72a-f62fbf924238/resourceGroups/ovn-qgwkn-rg/providers/Microsoft.Compute/virtualMachines/ovn-qgwkn-worker-canadacentral1-bskbf
+//
+//	providerID: azure:///subscriptions/ee2e2172-e246-4d4b-a72a-f62fbf924238/resourceGroups/ovn-qgwkn-rg/providers/Microsoft.Compute/virtualMachines/ovn-qgwkn-worker-canadacentral1-bskbf
+//
 // getInstance also validates that the instance has a (or several) NICs
 func (a *Azure) getInstance(node *corev1.Node) (*compute.VirtualMachine, error) {
 	providerData := strings.Split(node.Spec.ProviderID, "/")
@@ -341,7 +343,8 @@ func (a *Azure) getNetworkInterface(id string) (network.Interface, error) {
 }
 
 // This is what the subnet ID looks like on Azure:
-// 	ID: "/subscriptions/d38f1e38-4bed-438e-b227-833f997adf6a/resourceGroups/ci-ln-wzc83kk-002ac-qcghn-rg/providers/Microsoft.Network/virtualNetworks/ci-ln-wzc83kk-002ac-qcghn-vnet/subnets/ci-ln-wzc83kk-002ac-qcghn-worker-subnet"
+//
+//	ID: "/subscriptions/d38f1e38-4bed-438e-b227-833f997adf6a/resourceGroups/ci-ln-wzc83kk-002ac-qcghn-rg/providers/Microsoft.Network/virtualNetworks/ci-ln-wzc83kk-002ac-qcghn-vnet/subnets/ci-ln-wzc83kk-002ac-qcghn-worker-subnet"
 func (a *Azure) getNetworkResourceGroupAndSubnetAndNetnames(subnetID string) (string, string, string, error) {
 	providerData := strings.Split(subnetID, "/")
 	if len(providerData) != 11 {

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"path/filepath"
 	"sync"
 
@@ -95,10 +95,10 @@ type capacity struct {
 //  important for performing egress IP assignments by the network plugin.
 //  Specifically this is:
 
-//  - Interface - ID / Name, depending on the cloud's convention
-//  - IP address capacity for each node, where the capacity is either IP family
-//    agnostic or not.
-//  - Subnet information for the first network interface, IP family specific
+//   - Interface - ID / Name, depending on the cloud's convention
+//   - IP address capacity for each node, where the capacity is either IP family
+//     agnostic or not.
+//   - Subnet information for the first network interface, IP family specific
 type NodeEgressIPConfiguration struct {
 	Interface string   `json:"interface"`
 	IFAddr    ifAddr   `json:"ifaddr"`
@@ -145,7 +145,7 @@ func NewCloudProviderClient(cfg CloudProviderConfig) (CloudProviderIntf, error) 
 }
 
 func (c *CloudProvider) readSecretData(secret string) (string, error) {
-	data, err := ioutil.ReadFile(filepath.Join(c.cfg.CredentialDir, secret))
+	data, err := os.ReadFile(filepath.Join(c.cfg.CredentialDir, secret))
 	if err != nil {
 		return "", fmt.Errorf("unable to read secret data, err: %v", err)
 	}

--- a/pkg/cloudprovider/gcp.go
+++ b/pkg/cloudprovider/gcp.go
@@ -250,10 +250,11 @@ func (g *GCP) getNetworkInterfaces(instance *google.Instance) ([]*google.Network
 	return instance.NetworkInterfaces, nil
 }
 
-//  This is what the node's providerID looks like on GCP
-// 	spec:
-//   providerID: gce://openshift-gce-devel-ci/us-east1-b/ci-ln-pvr3lyb-f76d1-6w8mm-master-0
-//  i.e: projectID/zone/instanceName
+//	 This is what the node's providerID looks like on GCP
+//		spec:
+//	  providerID: gce://openshift-gce-devel-ci/us-east1-b/ci-ln-pvr3lyb-f76d1-6w8mm-master-0
+//	 i.e: projectID/zone/instanceName
+//
 // split out and return these components
 func splitGCPNode(node *corev1.Node) (project, zone, instance string, err error) {
 	u, err := url.Parse(node.Spec.ProviderID)

--- a/pkg/cloudprovider/openstack.go
+++ b/pkg/cloudprovider/openstack.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -74,7 +73,7 @@ func (o *OpenStack) initCredentials() error {
 	// Read the clouds.yaml file.
 	// That information is stored in secret cloud-credentials.
 	clientConfigFile := filepath.Join(o.cfg.CredentialDir, "clouds.yaml")
-	content, err := ioutil.ReadFile(clientConfigFile)
+	content, err := os.ReadFile(clientConfigFile)
 	if err != nil {
 		return fmt.Errorf("could read file %s, err: %q", clientConfigFile, err)
 	}
@@ -116,7 +115,7 @@ func (o *OpenStack) initCredentials() error {
 	// Read CA information - needed for self-signed certificates.
 	// That information is stored in ConfigMap kube-cloud-config.
 	caBundle := filepath.Join(o.cfg.ConfigDir, "ca-bundle.pem")
-	userCACert, err := ioutil.ReadFile(caBundle)
+	userCACert, err := os.ReadFile(caBundle)
 	if err == nil && string(userCACert) != "" {
 		klog.Infof("Custom CA bundle found at location '%s' - reading certificate information", caBundle)
 		certPool, err := x509.SystemCertPool()
@@ -168,8 +167,10 @@ func (o *OpenStack) initCredentials() error {
 // Throw an AlreadyExistingIPError if the IP provided is already associated with the
 // node, it's up to the caller to decide what to do with that.
 // NOTE: For OpenStack, this is a 2 step operation which is not atomic:
-//   a) Reserve a neutron port.
-//   b) Add the IP address to the allowed_address_pairs field.
+//
+//	a) Reserve a neutron port.
+//	b) Add the IP address to the allowed_address_pairs field.
+//
 // If step b) fails, then we will try to undo step a). However, if this undo fails,
 // then we will be in a situation where the user or an upper layer will have to call
 // ReleasePrivateIP to get out of this situation.
@@ -435,16 +436,17 @@ func (o *OpenStack) GetNodeEgressIPConfiguration(node *corev1.Node) ([]*NodeEgre
 }
 
 // getNeutronPortNodeEgressIPConfiguration renders the NeutronPortNodeEgressIPConfiguration for a given port.
-// * The interface is keyed by a neutron UUID
-// * If multiple IPv4 repectively multiple IPv6 subnets are attached to the same port, throw an error.
-// * The IP capacity is per port, per IP address family. It's ceiling is limited by the maximum of:
-//   a) The size of the subnet.
-//   b) An arbitrarily selected ceiling of `openstackMaxCapacity`.
-//   The number of unique IP addresses in allowed_address_pair and fixed_ips is subtracted from that ceiling.
-//   Keep in mind that the subnet size is an upper limit for the subnet, the port quota an upper limit for the
-//   project but that IP capacity is a per port value.
-//   The definition of this field does unfortunately not play very well with the way how neutron operates as there
-//   is no such thing as a per port quota or limit.
+//   - The interface is keyed by a neutron UUID
+//   - If multiple IPv4 repectively multiple IPv6 subnets are attached to the same port, throw an error.
+//   - The IP capacity is per port, per IP address family. It's ceiling is limited by the maximum of:
+//     a) The size of the subnet.
+//     b) An arbitrarily selected ceiling of `openstackMaxCapacity`.
+//     The number of unique IP addresses in allowed_address_pair and fixed_ips is subtracted from that ceiling.
+//     Keep in mind that the subnet size is an upper limit for the subnet, the port quota an upper limit for the
+//     project but that IP capacity is a per port value.
+//     The definition of this field does unfortunately not play very well with the way how neutron operates as there
+//     is no such thing as a per port quota or limit.
+//
 // TODO: How to determine the primary interface of an instance if multiple interfaces are attached?
 // TODO: As a solution, we currently report the EgressIP configuration for every attached interface, but other plugins
 // do not do this. Is the upper layer compatible with that?

--- a/pkg/cloudprovider/openstack_test.go
+++ b/pkg/cloudprovider/openstack_test.go
@@ -3,7 +3,7 @@ package cloudprovider
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"reflect"
@@ -403,7 +403,7 @@ func portListHandler(t *testing.T, w http.ResponseWriter, r *http.Request) {
 }
 
 func portCreationHandler(t *testing.T, w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		t.Fatalf("Unexpected error when reading from body of POST request to /ports, err %q", err)
 	}
@@ -533,7 +533,7 @@ func HandlePortGetUpdateDelete(t *testing.T, portID string) {
 
 			// PUT
 			th.TestHeader(t, r, "Content-Type", "application/json")
-			body, err := ioutil.ReadAll(r.Body)
+			body, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Fatalf("Unexpected error when reading from body of POST request to /ports, err %q", err)
 			}

--- a/pkg/controller/cloudprivateipconfig/cloudprivateipconfig_controller_racy_test.go
+++ b/pkg/controller/cloudprivateipconfig/cloudprivateipconfig_controller_racy_test.go
@@ -1,3 +1,4 @@
+//go:build race
 // +build race
 
 package controller

--- a/pkg/controller/cloudprivateipconfig/cloudprivateipconfig_controller_test.go
+++ b/pkg/controller/cloudprivateipconfig/cloudprivateipconfig_controller_test.go
@@ -148,8 +148,9 @@ func assertStateEquals(syncedState, expectedState []string) error {
 
 // TestSyncCloudPrivateIPConfig tests sync state for our CloudPrivateIPConfig
 // control loop. It does not test:
-//  - that the node specified is valid - that is handled by the admission controller
-//  - that the CloudPrivateIPConfig name is a valid IP - that is handled by OpenAPI
+//   - that the node specified is valid - that is handled by the admission controller
+//   - that the CloudPrivateIPConfig name is a valid IP - that is handled by OpenAPI
+//
 // Hence, all tests here are written with a valid spec. Moreover, this
 // controller neither deletes nor creates objects. Hence the only Kubernetes
 // action we need to verify is update, i.e: that the control loop updates the


### PR DESCRIPTION

Fix the log message from:
```
acquiring node lock for assigning ip address, node: %s, ip: %sci-ln-g470i52-1d09d-slz7m-worker-westus-6wt7k10.0.128.102
```
to:
```
Acquiring node lock for assigning ip address, node: ci-ln-g470i52-1d09d-slz7m-worker-westus-6wt7k, ip: 10.0.128.102
```

Additionally correct linter findings.