### PR TITLE
Add ApplicationSecurityGroups to InterfaceIPConfiguration

### DIFF
--- a/pkg/cloudprovider/azure.go
+++ b/pkg/cloudprovider/azure.go
@@ -112,6 +112,8 @@ func (a *Azure) AssignPrivateIP(ip net.IP, node *corev1.Node) error {
 	if err != nil {
 		return err
 	}
+	applicationSecurityGroups := (*networkInterfaces[0].IPConfigurations)[0].InterfaceIPConfigurationPropertiesFormat.ApplicationSecurityGroups
+
 	// Perform the operation against the first interface listed, which will be
 	// the primary interface (if it's defined as such) or the first one returned
 	// following the order Azure specifies.
@@ -128,6 +130,7 @@ func (a *Azure) AssignPrivateIP(ip net.IP, node *corev1.Node) error {
 			Subnet:                          (*networkInterface.IPConfigurations)[0].Subnet,
 			Primary:                         &untrue,
 			LoadBalancerBackendAddressPools: (*networkInterface.IPConfigurations)[0].LoadBalancerBackendAddressPools,
+			ApplicationSecurityGroups:       applicationSecurityGroups,
 		},
 	}
 	ipConfigurations = append(ipConfigurations, newIPConfiguration)


### PR DESCRIPTION
If a VM's nic has any Application Security Group's (ASG) assigned to it, the request to add an EgressIP will be rejected if it does not contain the exact list of those ASGs in the request to add it.

the error is below. This fixes that by adding ASGs in every request even if it's empty because none exist.

ERROR EXAMPLE:
E1103 16:16:02.226679       1 controller.go:165] error syncing '10.189.112.90': error assigning CloudPrivateIPConfig: "xxx.xxx.xxx.90" to node: "$NODE_NAME", err: network.InterfacesClient#CreateOrUpdate:
Failure sending request: StatusCode=0 -- Original Error: Code="AllIpConfigurationsOnANicMustBelongToTheSameApplicationSecurityGroups" Message="All IPConfigurations on a Network Interface should reference
the same set of Application Security Groups. IPConfiguration /subscriptions/XXXX/resourceGroups/openshift-ocp4azexp2/providers/Microsoft.Network/networkInterfaces/YYYY-nic/ipConfigurations/pipConfig
references ASG(s) /subscriptions/XXX/resourceGroups/openshift-RG-extras/providers/Microsoft.Network/applicationSecurityGroups/ASG_NAME, wheras IPConfiguration
/subscriptions/XXX/resourceGroups/openshift-RG/providers/Microsoft.Network/networkInterfaces/ocp4azexp2-qrfgh-worker-northeurope2-xdbbp-nic/ipConfigurations/xxx_xxx.xxx.xxx.90
references ASG(s) ." Details=[], requeuing in cloud-private-ip-config workqueue

JIRA: https://issues.redhat.com/browse/OCPBUGS-3919

Signed-off-by: Jamo Luhrsen <jluhrsen@gmail.com>