### PR TITLE
Add MovePrivateIP and its OpenStack implementation

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -59,6 +59,20 @@ type CloudProviderIntf interface {
 	GetNodeEgressIPConfiguration(node *corev1.Node, cloudPrivateIPConfigs []*v1.CloudPrivateIPConfig) ([]*NodeEgressIPConfiguration, error)
 }
 
+// CloudProviderWithMoveIntf is additional interface that can be added to cloud
+// plugins that can benefit from a separate set of operations on IP address
+// failover, instead of running ReleasePrivateIP followed by AssignPrivateIP.
+type CloudProviderWithMoveIntf interface {
+	// MovePrivateIP is called instead of ReleasePrivateIP followed by
+	// AssignPrivateIP if plugin implements CloudProviderWithMoveIntf. It
+	// should effectively move IP address from nodeToDel to nodeToAdd, but not
+	// necessarily remove resources from the cloud. E.g. in case of OpenStack
+	// we don't want to delete the reservation Neutron port, but rather just
+	// manipulate allowedAddressPairs on the nodeToDel and nodeToAdd ports to
+	// move the IP from one node to another.
+	MovePrivateIP(ip net.IP, nodeToAdd *corev1.Node, nodeToDel *corev1.Node) error
+}
+
 // CloudProviderConfig is all the command-line options needed to initialize
 // a cloud provider client.
 type CloudProviderConfig struct {

--- a/pkg/cloudprovider/openstack_test.go
+++ b/pkg/cloudprovider/openstack_test.go
@@ -408,6 +408,14 @@ func portListHandler(t *testing.T, w http.ResponseWriter, r *http.Request) {
 	deviceID := r.URL.Query().Get("device_id")
 	deviceOwner := r.URL.Query().Get("device_owner")
 	networkID := r.URL.Query().Get("network_id")
+	IPs := r.URL.Query()["fixed_ips"]
+	IP := ""
+	for _, val := range IPs {
+		if strings.HasPrefix(val, "ip_address=") {
+			IP = strings.TrimPrefix(val, "ip_address=")
+			break
+		}
+	}
 
 	var portList []neutronports.Port
 	for _, p := range portMap {
@@ -419,6 +427,17 @@ func portListHandler(t *testing.T, w http.ResponseWriter, r *http.Request) {
 		}
 		if networkID != "" && networkID != p.NetworkID {
 			continue
+		}
+		if IP != "" {
+			matched := false
+			for _, fixedIP := range p.FixedIPs {
+				if fixedIP.IPAddress == IP {
+					matched = true
+				}
+			}
+			if !matched {
+				continue
+			}
 		}
 		portList = append(portList, p)
 	}
@@ -1165,11 +1184,10 @@ func TestReserveAndReleaseNeutronIPAddress(t *testing.T) {
 		},
 		// ... and try to create a duplicate of it.
 		{
-			subnet:    subnetMap["de0cda14-6ac6-4439-bc94-da0a27938b7b"],
-			ip:        net.ParseIP("2000::9"), // reserving the same IP address 2x shall fail
-			reserve:   true,
-			nodeName:  "node1",
-			errString: "but got 409 instead",
+			subnet:   subnetMap["de0cda14-6ac6-4439-bc94-da0a27938b7b"],
+			ip:       net.ParseIP("2000::9"), // reserving the same IP address 2x should find the existing port
+			reserve:  true,
+			nodeName: "node1",
 		},
 		// Release the first IPv6 port.
 		{


### PR DESCRIPTION
Up until now when an IP is failed over from one node to another, `CloudPrivateIPConfigController` will call `ReleasePrivateIP` with the node being failed over and `AssignPrivateIP` with the new node.

This is far from ideal for OpenStack platform. In this case in addition to adding the IP to the `allowedAddressPairs` on the node's port, we also create a port in Neutron to act as a reservation of that IP, so that it won't be taken by another node being created. With traditional model on every failover the reservation port would get removed, making a race condition "stealing" the IP possible. It's also problematic if user assigned a Neutron floating IP to that reservation port to have a predictible SNAT address for EgressIP traffic going outside the cluster. On failover such association would be lost and manual intervention would be needed to assign FIP to new reservation port.

This commit introduces an optional `CloudProviderWithMoveIntf` interface that has `MovePrivateIP` operation to be called on IP fail over. This operation is supposed to move the IP assignment from one node to another, but doesn't require deleting cloud resources if not necessary. The required logic is added to `CloudPrivateIPConfigController` to call `MovePrivateIP` on IP fail over if plugin implements the `CloudProviderWithMoveIntf` interface.

An implementation of `MovePrivateIP` is added to the OpenStack plugin, that will remove the IP from old node's `allowedAddressPairs`, add the IP to the new node's `allowedAddressPairs`, but won't touch the Neutron port that serves as a reservation of that IP.