### PR TITLE
OpenStack: Fix race condition in TestGetNodeEgressIPConfiguration

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -104,6 +104,12 @@ type NodeEgressIPConfiguration struct {
 	Capacity  capacity `json:"capacity"`
 }
 
+// String implements the stringer interface for pointers to NodeEgressIPConfiguration. This is used for the unit tests
+// as it simplifies printing of the actual values instead of returning the memory address that is being pointed to.
+func (n *NodeEgressIPConfiguration) String() string {
+	return fmt.Sprintf("%v", *n)
+}
+
 func NewCloudProviderClient(cfg CloudProviderConfig) (CloudProviderIntf, error) {
 	var cloudProviderIntf CloudProviderIntf
 

--- a/pkg/cloudprovider/openstack.go
+++ b/pkg/cloudprovider/openstack.go
@@ -453,7 +453,7 @@ func (o *OpenStack) GetNodeEgressIPConfiguration(node *corev1.Node, cloudPrivate
 			}
 		}
 		klog.Infof("Skipping interface config. Neither the IPv4 nor the IPv6 network contain the first InternalIP "+
-			" of the node. Interface config: %q, IPv4 InternalIP: %q, IPv6 InternalIP: %q",
+			"of the node. Interface config: %q, IPv4 InternalIP: %q, IPv6 InternalIP: %q",
 			config, ipv4InternalIP, ipv6InternalIP)
 	}
 


### PR DESCRIPTION
Fix a race condition in TestGetNodeEgressIPConfiguration unit test due to unstable map order.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>