### PR TITLE
OCPBUGS-10526: pull project name from subnet uri

### DIFF
--- a/pkg/cloudprovider/gcp.go
+++ b/pkg/cloudprovider/gcp.go
@@ -130,7 +130,7 @@ func (g *GCP) ReleasePrivateIP(ip net.IP, node *corev1.Node) error {
 }
 
 func (g *GCP) GetNodeEgressIPConfiguration(node *corev1.Node, cloudPrivateIPConfigs []*v1.CloudPrivateIPConfig) ([]*NodeEgressIPConfiguration, error) {
-	project, _, instance, err := g.getInstance(node)
+	_, _, instance, err := g.getInstance(node)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving instance associated with node, err: %v", err)
 	}
@@ -144,7 +144,8 @@ func (g *GCP) GetNodeEgressIPConfiguration(node *corev1.Node, cloudPrivateIPConf
 		config := &NodeEgressIPConfiguration{
 			Interface: networkInterface.Name,
 		}
-		v4Subnet, v6Subnet, err := g.getSubnet(project, networkInterface)
+
+		v4Subnet, v6Subnet, err := g.getSubnet(networkInterface)
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving the network interface subnets, err: %v", err)
 		}
@@ -184,12 +185,14 @@ func (g *GCP) waitForCompletion(project, zone, opName string) error {
 	return nil
 }
 
-func (g *GCP) getSubnet(project string, networkInterface *google.NetworkInterface) (*net.IPNet, *net.IPNet, error) {
+func (g *GCP) getSubnet(networkInterface *google.NetworkInterface) (*net.IPNet, *net.IPNet, error) {
 	var v4Subnet, v6Subnet *net.IPNet
-	region, subnet, err := g.parseSubnet(networkInterface.Subnetwork)
+	project, region, subnet, err := g.parseSubnet(networkInterface.Subnetwork)
+
 	if err != nil {
 		return nil, nil, err
 	}
+
 	subnetResult, err := g.client.Subnetworks.Get(project, region, subnet).Do()
 	if err != nil {
 		return nil, nil, err
@@ -226,7 +229,7 @@ func (g *GCP) getCapacity(networkInterface *google.NetworkInterface, cloudPrivat
 	return defaultGCPPrivateIPCapacity + cloudPrivateIPsCount - currentIPv4Usage - currentIPv6Usage
 }
 
-// getInstance retrieves the GCP instance referrred by the Node object.
+// getInstance retrieves the GCP instance referred by the Node object.
 // returns the project and zone name as well.
 func (g *GCP) getInstance(node *corev1.Node) (string, string, *google.Instance, error) {
 	project, zone, instance, err := splitGCPNode(node)
@@ -279,10 +282,11 @@ func splitGCPNode(node *corev1.Node) (project, zone, instance string, err error)
 // - https://www.googleapis.com/compute/v1/projects/project/regions/region/subnetworks/subnetwork
 // OR
 // - regions/region/subnetworks/subnetwork
-func (g *GCP) parseSubnet(subnetURL string) (string, string, error) {
+func (g *GCP) parseSubnet(subnetURL string) (string, string, string, error) {
 	subnetURLParts := strings.Split(subnetURL, "/")
 	if len(subnetURLParts) != 11 {
-		return "", "", UnexpectedURIError(subnetURL)
+		return "", "", "", UnexpectedURIError(subnetURL)
 	}
-	return subnetURLParts[len(subnetURLParts)-3], subnetURLParts[len(subnetURLParts)-1], nil
+	return subnetURLParts[len(subnetURLParts)-5], subnetURLParts[len(subnetURLParts)-3],
+		subnetURLParts[len(subnetURLParts)-1], nil
 }

--- a/pkg/cloudprovider/gcp_test.go
+++ b/pkg/cloudprovider/gcp_test.go
@@ -29,3 +29,23 @@ func TestSplitGCPNode(t *testing.T) {
 		t.Fatalf("wrong name: %s", instance)
 	}
 }
+
+func TestParseSubnet(t *testing.T) {
+	subnetURI := "https://www.googleapis.com/compute/v1/projects/openshift-qe-shared-vpc/regions/us-central1/subnetworks/installer-shared-vpc-subnet-2"
+	gcp := &GCP{}
+
+	project, region, subnet, err := gcp.parseSubnet(subnetURI)
+
+	if project != "openshift-qe-shared-vpc" {
+		t.Fatalf("wrong project: %s", project)
+	}
+	if region != "us-central1" {
+		t.Fatalf("wrong region: %s", region)
+	}
+	if subnet != "installer-shared-vpc-subnet-2" {
+		t.Fatalf("wrong subnet: %s", subnet)
+	}
+	if err != nil {
+		t.Fatalf("did not expect err: %s", err)
+	}
+}


### PR DESCRIPTION
In the case of GCP XPN the subnet project is not the same as the project that is determined from the providerID of the node. That is because the network resources are from a shared-vpc and come from a different "shared" project.