### PR TITLE
OCPBUGS-13140: increase GCP egress ip capacity to 100 from 10

### DIFF
--- a/pkg/cloudprovider/gcp.go
+++ b/pkg/cloudprovider/gcp.go
@@ -15,11 +15,11 @@ import (
 
 const (
 	PlatformTypeGCP = "GCP"
-	// GCP hard-codes the amount of alias IPs that can be assigned to a NIC to 10 -
-	// independently of IP family, so we need to retrive the amount of alias IPs
-	// already in use by default and subtract from 10. See:
+	// GCP hard-codes the amount of alias IPs that can be assigned to a NIC to 100 -
+	// independently of IP family, so we need to retrieve the amount of alias IPs
+	// already in use by default and subtract from 100. See:
 	// https://cloud.google.com/vpc/docs/quota#per_instance .
-	defaultGCPPrivateIPCapacity = 10
+	defaultGCPPrivateIPCapacity = 100
 )
 
 // GCP implements the API wrapper for talking

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -104,14 +104,7 @@ func (n *NodeController) SyncHandler(key string) error {
 		klog.Infof("corev1.Node: '%s' in work queue no longer exists", key)
 		return nil
 	}
-	// If the node already has the annotation (ex: if we restart it is expected
-	// that the nodes would) we skip it. Subnets won't change and we are only
-	// interested in conveying the default assignment capacity that the node had
-	// when it started existing. It's up to the network plugin to track how much
-	// capacity it has left depending on the assignments it performs.
-	if _, ok := node.Annotations[nodeEgressIPConfigAnnotationKey]; ok {
-		return nil
-	}
+
 	// Skip synchronization if this node is still uninitialized by the Cloud Controller Manager,
 	// meaning that it still has taint cloudproviderapi.TaintExternalCloudProvider.
 	if taintKeyExists(node.Spec.Taints, cloudproviderapi.TaintExternalCloudProvider) {


### PR DESCRIPTION
the original implementation [0] was restricted to 10 IP Aliases [1], but has since been increased to 100 [2]. The networking model for GCP has more explanation here [3].

[0] https://github.com/openshift/cloud-network-config-controller/commit/f6f21a0328f8e942a430f1ba8c592c7c8e638557
[1] https://web.archive.org/web/20211021043215/https://cloud.google.com/vpc/docs/quota#per_instance
[2] https://cloud.google.com/vpc/docs/quota#per_instance
[3] https://github.com/openshift/enhancements/blob/master/enhancements/network/cloud-egress-ip.md#gcp