### PR TITLE
OCPBUGS-15805: Azure: Handle already existing IP configurations

### DIFF
--- a/pkg/cloudprovider/azure.go
+++ b/pkg/cloudprovider/azure.go
@@ -136,6 +136,16 @@ func (a *Azure) AssignPrivateIP(ip net.IP, node *corev1.Node) error {
 			ApplicationSecurityGroups:       applicationSecurityGroups,
 		},
 	}
+	for _, ipCfg := range ipConfigurations {
+		if ipCfg.PrivateIPAddress != nil && *ipCfg.PrivateIPAddress == ipc {
+			json, err := ipCfg.MarshalJSON()
+			if err != nil {
+				klog.Errorf("Failed to marshall the ip configuration: %v", err)
+			}
+			klog.Warningf("IP: %s is already assigned to node: %s with the ip configuration: %s", ipc, node.Name, json)
+			return AlreadyExistingIPError
+		}
+	}
 	ipConfigurations = append(ipConfigurations, newIPConfiguration)
 	networkInterface.IPConfigurations = &ipConfigurations
 	// Send the request


### PR DESCRIPTION
If a secondary IP is already configured CNCC should return AlreadyExistingIPError instead of trying to add the same IP again.