### PR TITLE
OCPBUGS-28282: Add Snyk file to exclude vendor dependent libraries on scan

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,22 @@
+# References:
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+# https://docs.snyk.io/snyk-cli/commands/ignore
+exclude:
+  global:
+    # TODO: silence security warnings for now, but follow up with
+    # https://issues.redhat.com/browse/SDN-4462.
+    - vendor/k8s.io/client-go/util/cert/server_inspection.go
+    - vendor/github.com/Azure/go-autorest/autorest/azure/rp.go
+    - vendor/github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/local/server.go
+    - vendor/k8s.io/klog/v2/klog_file.go
+    - vendor/github.com/openshift/library-go/pkg/crypto/crypto.go
+    - vendor/github.com/Azure/go-autorest/autorest/adal/token.go
+    - vendor/github.com/aws/aws-sdk-go/aws/credentials/ssocreds/provider.go
+    - vendor/github.com/google/uuid/hash.go
+    - vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/resource_cache.go
+    - vendor/github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/accesstokens/accesstokens.go
+    - vendor/golang.org/x/crypto/pkcs12/pbkdf.go
+    - vendor/github.com/Azure/azure-sdk-for-go/sdk/azidentity/azidentity.go
+    - vendor/github.com/openshift/api/config/v1/types_oauth.go
+    - vendor/github.com/Azure/azure-sdk-for-go/sdk/azidentity/username_password_credential.go
+    - vendor/github.com/aws/aws-sdk-go/service/sts/api.go


### PR DESCRIPTION
This commit makes .snyk file to exclude azure specific vendor directories from vulnerability scan, it would suppress scan errors [html](https://cov01.lab.eng.brq2.redhat.com/osh/task/432276/log/ose-cloud-network-config-controller-container-v4.13.0-202401190520.p0.g78d453a.assembly.stream/scan-results-imp.html) / [json](https://cov01.lab.eng.brq2.redhat.com/osh/task/432276/log/ose-cloud-network-config-controller-container-v4.13.0-202401190520.p0.g78d453a.assembly.stream/scan-results-imp.js) reported for azure dependency libraries.