### PR TITLE
OCPBUGS-27422: Avoid nil pointer panic while assigning private IP on Azure

### DIFF
--- a/pkg/cloudprovider/azure.go
+++ b/pkg/cloudprovider/azure.go
@@ -170,9 +170,9 @@ func (a *Azure) AssignPrivateIP(ip net.IP, node *corev1.Node) error {
 	// UserDefinedRouting, which doesn't impose such constraints on secondary IPs.
 	loadBalancerBackendAddressPoolsArgument := (*networkInterface.IPConfigurations)[0].LoadBalancerBackendAddressPools
 	var attachedOutboundRule *network.SubResource
-	if (*networkInterface.IPConfigurations)[0].LoadBalancerBackendAddressPools != nil {
-	OuterLoop:
-		for _, ipconfig := range *networkInterface.IPConfigurations {
+OuterLoop:
+	for _, ipconfig := range *networkInterface.IPConfigurations {
+		if ipconfig.LoadBalancerBackendAddressPools != nil {
 			for _, pool := range *ipconfig.LoadBalancerBackendAddressPools {
 				if pool.ID == nil {
 					continue


### PR DESCRIPTION
If any previously assigned IP present in IP configurations of the NIC is removed from public load balancer backend pool then cloud-network-config-controller starts to panic due to a nil pointer.

This PR checks whether load balancer backend pull is nil or not before proceeding further.