### PR TITLE
OCPBUGS-30146: Serialize scheme construction to prevent panic

### DIFF
--- a/pkg/controller/cloudprivateipconfig/cloudprivateipconfig_controller.go
+++ b/pkg/controller/cloudprivateipconfig/cloudprivateipconfig_controller.go
@@ -9,7 +9,6 @@ import (
 
 	cloudnetworkv1 "github.com/openshift/api/cloudnetwork/v1"
 	cloudnetworkclientset "github.com/openshift/client-go/cloudnetwork/clientset/versioned"
-	cloudnetworkscheme "github.com/openshift/client-go/cloudnetwork/clientset/versioned/scheme"
 	cloudnetworkinformers "github.com/openshift/client-go/cloudnetwork/informers/externalversions/cloudnetwork/v1"
 	cloudnetworklisters "github.com/openshift/client-go/cloudnetwork/listers/cloudnetwork/v1"
 	"github.com/openshift/cloud-network-config-controller/pkg/cloudprivateipconfig"
@@ -17,9 +16,7 @@ import (
 	controller "github.com/openshift/cloud-network-config-controller/pkg/controller"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	coreinformers "k8s.io/client-go/informers/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 	corelisters "k8s.io/client-go/listers/core/v1"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -67,8 +64,6 @@ func NewCloudPrivateIPConfigController(
 	cloudNetworkClientset cloudnetworkclientset.Interface,
 	cloudPrivateIPConfigInformer cloudnetworkinformers.CloudPrivateIPConfigInformer,
 	nodeInformer coreinformers.NodeInformer) (*controller.CloudNetworkConfigController, error) {
-
-	utilruntime.Must(cloudnetworkscheme.AddToScheme(scheme.Scheme))
 
 	cloudPrivateIPConfigController := &CloudPrivateIPConfigController{
 		nodesLister:                nodeInformer.Lister(),


### PR DESCRIPTION
Within CI, seen error:
"fatal error: concurrent map read and map write"

Before this commit, this is seen when components
were reading the scheme maps and later we attempted to write to them when starting the main controller.

Scheme construct should be performed when an app begins before anything starts utilizing them.

```
fatal error: concurrent map read and map write

goroutine 31 [running]:
k8s.io/apimachinery/pkg/runtime.(*Scheme).New(0xc0002e81c0, {{0x0, 0x0}, {0xc000bd17c6, 0x2}, {0xc000bd17c0, 0x6}})
	/go/src/github.com/openshift/cloud-network-config-controller/vendor/k8s.io/apimachinery/pkg/runtime/scheme.go:296 +0x67

goroutine 82 [runnable]:
k8s.io/apimachinery/pkg/runtime.(*Scheme).AddKnownTypeWithName(0xc0002e81c0, {{0x2ede1b9, 0x1a}, {0x2eb1bb8, 0x2}, {0x2ebb205, 0xa}}, {0x3388ab8?, 0xc00062e540})
	/go/src/github.com/openshift/cloud-network-config-controller/vendor/k8s.io/apimachinery/pkg/runtime/scheme.go:176 +0x2b2
```

See CI run [1] for full stack traces:
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-aws-ovn/1763616334094012416/artifacts/e2e-aws-ovn/run-e2e/artifacts/TestUpgradeControlPlane/namespaces/e2e-clusters-5tmhk-example-j4msj/core/pods/logs/cloud-network-config-controller-9689f46c8-w8h64-controller-previous.log

/hold until tested on cluster.