### PR TITLE
OCPBUGS-33154: Incorrect use of go wait groups

### DIFF
--- a/cmd/cloud-network-config-controller/main.go
+++ b/cmd/cloud-network-config-controller/main.go
@@ -195,7 +195,6 @@ func main() {
 						klog.Exitf("Error running CloudPrivateIPConfig controller: %s", err.Error())
 					}
 				}()
-				wg.Add(1)
 
 				// AWS and OpenStack use a configmap "kube-cloud-config" to keep track of additional
 				// data such as the ca-bundle.pem. Add a controller that restarts the operator if that configmap
@@ -222,7 +221,8 @@ func main() {
 						}
 					}()
 				}
-
+				
+				wg.Add(1)
 				go func() {
 					defer wg.Done()
 					if err = nodeController.Run(stopCh); err != nil {


### PR DESCRIPTION
Minor change to the wait group to ensure the controller does not hang.  

The wg.Add(1) (line 198) should be moved closer to the function it is waiting for (line 226).

Having a function (that could exit) between wg.add() and the function with the matching wg.done() could lead to a state where the controller hangs, waiting for the wg.done() that is never called.