### PR TITLE
OCPBUGS-33617: Avoid panic when looking up attachedOutboundRule.ID in azure

### DIFF
--- a/pkg/cloudprovider/azure.go
+++ b/pkg/cloudprovider/azure.go
@@ -191,7 +191,7 @@ OuterLoop:
 						attachedOutboundRule = realPool.BackendAddressPoolPropertiesFormat.OutboundRule
 						break OuterLoop
 					}
-					if realPool.BackendAddressPoolPropertiesFormat.OutboundRules != nil {
+					if realPool.BackendAddressPoolPropertiesFormat.OutboundRules != nil && len(*realPool.BackendAddressPoolPropertiesFormat.OutboundRules) > 0 {
 						loadBalancerBackendAddressPoolsArgument = nil
 						attachedOutboundRule = &(*realPool.BackendAddressPoolPropertiesFormat.OutboundRules)[0]
 						break OuterLoop
@@ -201,9 +201,14 @@ OuterLoop:
 		}
 	}
 	if loadBalancerBackendAddressPoolsArgument == nil {
+		outboundRuleStr := ""
+		if attachedOutboundRule != nil && attachedOutboundRule.ID != nil {
+			// https://issues.redhat.com/browse/OCPBUGS-33617 showed that there can be a rule without an ID...
+			outboundRuleStr = fmt.Sprintf(": %s", *attachedOutboundRule.ID)
+		}
 		klog.Warningf("Egress IP %s will have no outbound connectivity except for the infrastructure subnet: "+
-			"omitting backend address pool when adding secondary IP: it has an outbound rule already: %s",
-			ipc, *attachedOutboundRule.ID)
+			"omitting backend address pool when adding secondary IP: it has an outbound rule already%s",
+			ipc, outboundRuleStr)
 	}
 	newIPConfiguration := network.InterfaceIPConfiguration{
 		Name: &name,


### PR DESCRIPTION
On a deployed cluster a panic happened here: https://github.com/openshift/cloud-network-config-controller/blob/0b191405af9a0632a09d9f857bb550c7efbba20f/pkg/cloudprovider/azure.go#L176

 It looks like the ID in `realPool.BackendAddressPoolPropertiesFormat.OutboundRule` might be `nil` in the pool we've just fetched: `realPool, err := a.getBackendAddressPool(*pool.ID)`. This is not at all expected, but let's check against nil pointers before dereferencing the ID.