### PR TITLE
NO-JIRA:Update linter file

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,15 +1,14 @@
-run:
-  skip-dirs:
+issues:
+  exclude-dirs:
     - vendor
 
-  skip-files:
+  exclude-files:
     - ".*\\_test.go$"
 
 linters:
   disable-all: true
   enable:
     - gofmt
-    - deadcode
     - errcheck
     - gofmt
     - gosimple
@@ -17,8 +16,6 @@ linters:
     - ineffassign
     - nosprintfhostport
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
     - exportloopref

--- a/cmd/cloud-network-config-controller/main.go
+++ b/cmd/cloud-network-config-controller/main.go
@@ -221,7 +221,7 @@ func main() {
 						}
 					}()
 				}
-				
+
 				wg.Add(1)
 				go func() {
 					defer wg.Done()


### PR DESCRIPTION
Update .golangci.yaml
- run.skip-dirs is now issues.exclude-dirs
- run-skip-files is now issues.skip-files
- three linters are now deprecated and skipped automatically, so we might as well remove them: deadcode, structcheck, varcheck