### PR TITLE
HOSTEDCP-2035: Use Client Cert Auth for ARO HCP deployments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0
 	github.com/Azure/go-autorest/autorest v0.11.27
 	github.com/aws/aws-sdk-go v1.37.8
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/google/uuid v1.6.0
 	github.com/gophercloud/gophercloud v0.25.1-0.20220718160629-0721d75e876f
 	github.com/gophercloud/utils v0.0.0-20220307143606-8e7800759d16
@@ -52,7 +53,6 @@ require (
 	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/pkg/filewatcher/filewatcher.go
+++ b/pkg/filewatcher/filewatcher.go
@@ -1,0 +1,68 @@
+package filewatcher
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+	"k8s.io/klog/v2"
+)
+
+var watchCertificateFileOnce sync.Once
+
+// WatchFileForChanges watches the file, fileToWatch, for changes. If the file contents have changed, the pod this
+// function is running on will be restarted.
+func WatchFileForChanges(fileToWatch string) error {
+	var err error
+
+	// This starts only one occurrence of the file watcher, which watches the file, fileToWatch.
+	watchCertificateFileOnce.Do(func() {
+		klog.Infof("Starting the file change watcher on file, %s", fileToWatch)
+
+		// Update the file path to watch in case this is a symlink
+		fileToWatch, err = filepath.EvalSymlinks(fileToWatch)
+		if err != nil {
+			return
+		}
+		klog.Infof("Watching file, %s", fileToWatch)
+
+		// Start the file watcher to monitor file changes
+		go func() {
+			err := checkForFileChanges(fileToWatch)
+			klog.Errorf("Error checking for file changes: %v", err)
+		}()
+	})
+	return err
+}
+
+// checkForFileChanges starts a new file watcher. If the file is changed, the pod running this function will exit.
+func checkForFileChanges(path string) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if ok && (event.Has(fsnotify.Write) || event.Has(fsnotify.Chmod) || event.Has(fsnotify.Remove)) {
+					klog.Infof("file, %s, was modified, exiting...", event.Name)
+					os.Exit(0)
+				}
+			case err, ok := <-watcher.Errors:
+				if ok {
+					klog.Errorf("file watcher error: %v", err)
+				}
+			}
+		}
+	}()
+
+	err = watcher.Add(path)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Use Client Certificate Authentication for ARO HCP deployments. HyperShift will pass the needed environment variables for this authentication method: ARO_HCP_MI_CLIENT_ID, ARO_HCP_TENANT_ID, and ARO_HCP_CLIENT_CERTIFICATE_PATH.