### PR TITLE
OSASINFRA-3755: Prefer CA cert from credentials secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ type: Opaque
 
 ```
 tree /etc/secret/cloudprovider
+├── cacert
 └── cloud.yaml
 ```
 
@@ -193,12 +194,18 @@ or as a Kubernetes secret defined as:
 apiVersion: v1
 data:
   clouds.yaml: <base64 string>
+  cacert: <base64 string>
 kind: Secret
 metadata:
   name: cloud-credentials
   namespace: cloud-network-config-controller
 type: Opaque
 ```
+
+> Note: The `cacert` file/field is optional. If provided, then the operator
+> will assume that this is a valid CA chain and will use this data when talking
+> to the OpenStack API.
+
 ### ConfigMap
 
 The Cluster Network Operator will create a ConfigMap named `kube-cloud-config`


### PR DESCRIPTION
In openshift/cloud-credential-operator/pull/780, we have added the ability for `cloud-credential-operator` to consume a CA cert from the root credentials secret and to include in the credentials secrets it provisions.
In openshift/installer/pull/9194, we have modified the Installer to start setting this field where necessary.

Adapt `cloud-network-config-operator` to allow it to start consuming the CA cert from this place. We maintain fallbacks for the previous locations of the cert for now, but these can be removed in the next release.
