### PR TITLE
OCPBUGS-45056: Azure: Don't add EgressIP to LB backends

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -7,6 +7,7 @@ exclude:
     # https://issues.redhat.com/browse/SDN-4462.
     # ** KEEP THIS LIST SORTED FOR CONSISTENCY **
     - vendor/github.com/aws/aws-sdk-go/aws/credentials/ssocreds/provider.go
+    - vendor/github.com/aws/aws-sdk-go/aws/endpoints/dep_service_ids.go
     - vendor/github.com/aws/aws-sdk-go/service/sts/api.go
     - vendor/github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/local/server.go
     - vendor/github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/accesstokens/accesstokens.go
@@ -14,6 +15,8 @@ exclude:
     - vendor/github.com/Azure/azure-sdk-for-go/sdk/azidentity/username_password_credential.go
     - vendor/github.com/Azure/go-autorest/autorest/adal/token.go
     - vendor/github.com/Azure/go-autorest/autorest/azure/rp.go
+    - vendor/github.com/gofrs/uuid/v5/generator.go
+    - vendor/github.com/google/s2a-go/internal/v2/tlsconfigstore/tlsconfigstore.go
     - vendor/github.com/google/uuid/hash.go
     - vendor/github.com/openshift/api/config/v1/types_oauth.go
     - vendor/github.com/openshift/library-go/pkg/crypto/crypto.go
@@ -21,3 +24,4 @@ exclude:
     - vendor/golang.org/x/crypto/pkcs12/pbkdf.go
     - vendor/k8s.io/client-go/util/cert/server_inspection.go
     - vendor/k8s.io/klog/v2/klog_file.go
+    - vendor/sigs.k8s.io/controller-runtime/pkg/log/log.go

--- a/.snyk
+++ b/.snyk
@@ -5,18 +5,19 @@ exclude:
   global:
     # TODO: silence security warnings for now, but follow up with
     # https://issues.redhat.com/browse/SDN-4462.
-    - vendor/k8s.io/client-go/util/cert/server_inspection.go
-    - vendor/github.com/Azure/go-autorest/autorest/azure/rp.go
-    - vendor/github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/local/server.go
-    - vendor/k8s.io/klog/v2/klog_file.go
-    - vendor/github.com/openshift/library-go/pkg/crypto/crypto.go
-    - vendor/github.com/Azure/go-autorest/autorest/adal/token.go
+    # ** KEEP THIS LIST SORTED FOR CONSISTENCY **
     - vendor/github.com/aws/aws-sdk-go/aws/credentials/ssocreds/provider.go
-    - vendor/github.com/google/uuid/hash.go
-    - vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/resource_cache.go
-    - vendor/github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/accesstokens/accesstokens.go
-    - vendor/golang.org/x/crypto/pkcs12/pbkdf.go
-    - vendor/github.com/Azure/azure-sdk-for-go/sdk/azidentity/azidentity.go
-    - vendor/github.com/openshift/api/config/v1/types_oauth.go
-    - vendor/github.com/Azure/azure-sdk-for-go/sdk/azidentity/username_password_credential.go
     - vendor/github.com/aws/aws-sdk-go/service/sts/api.go
+    - vendor/github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/local/server.go
+    - vendor/github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/oauth/ops/accesstokens/accesstokens.go
+    - vendor/github.com/Azure/azure-sdk-for-go/sdk/azidentity/azidentity.go
+    - vendor/github.com/Azure/azure-sdk-for-go/sdk/azidentity/username_password_credential.go
+    - vendor/github.com/Azure/go-autorest/autorest/adal/token.go
+    - vendor/github.com/Azure/go-autorest/autorest/azure/rp.go
+    - vendor/github.com/google/uuid/hash.go
+    - vendor/github.com/openshift/api/config/v1/types_oauth.go
+    - vendor/github.com/openshift/library-go/pkg/crypto/crypto.go
+    - vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/resource_cache.go
+    - vendor/golang.org/x/crypto/pkcs12/pbkdf.go
+    - vendor/k8s.io/client-go/util/cert/server_inspection.go
+    - vendor/k8s.io/klog/v2/klog_file.go

--- a/pkg/cloudprovider/azure.go
+++ b/pkg/cloudprovider/azure.go
@@ -3,13 +3,14 @@ package cloudprovider
 import (
 	"context"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"k8s.io/utils/ptr"
 	"net"
 	"os"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"k8s.io/utils/ptr"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -196,67 +197,15 @@ func (a *Azure) AssignPrivateIP(ip net.IP, node *corev1.Node) error {
 	// Assign the IP
 	ipConfigurations := networkInterface.Properties.IPConfigurations
 	name := fmt.Sprintf("%s_%s", node.Name, ipc)
-	untrue := false
 
-	// In some Azure setups (Azure private, public ARO, private ARO) outbound connectivity is achieved through
-	// outbound rules tied to the backend address pool of the primary IP of the VM NIC. An Azure constraint
-	// forbids the creation of a secondary IP tied to such address pool and would result in
-	// OutboundRuleCannotBeUsedWithBackendAddressPoolThatIsReferencedBySecondaryIpConfigs.
-	// Work around it by not specifying the backend address pool when an outbound rule is set, even though
-	// that means preventing outbound connectivity to the egress IP, which will be able to reach the
-	// infrastructure subnet nonetheless. In public Azure clusters, outbound connectivity is achieved through
-	// UserDefinedRouting, which doesn't impose such constraints on secondary IPs.
-	loadBalancerBackendAddressPoolsArgument := networkInterface.Properties.IPConfigurations[0].Properties.LoadBalancerBackendAddressPools
-	var attachedOutboundRule *armnetwork.SubResource
-OuterLoop:
-	for _, ipconfig := range networkInterface.Properties.IPConfigurations {
-		if ipconfig.Properties.LoadBalancerBackendAddressPools != nil {
-			for _, pool := range ipconfig.Properties.LoadBalancerBackendAddressPools {
-				if pool.ID == nil {
-					continue
-				}
-				// for some reason, the struct for the pool above is not entirely filled out:
-				//     BackendAddressPoolPropertiesFormat:(*network.BackendAddressPoolPropertiesFormat)(nil)
-				// Do a separate get for this pool in order to check whether there are any outbound rules
-				// attached to it
-				realPool, err := a.getBackendAddressPool(ptr.Deref(pool.ID, ""))
-				if err != nil {
-					return fmt.Errorf("error looking up backend address pool %s with ID %s: %v", ptr.Deref(pool.Name, ""), ptr.Deref(pool.ID, ""), err)
-				}
-				if realPool.Properties.LoadBalancerBackendAddresses != nil && len(realPool.Properties.LoadBalancerBackendAddresses) > 0 {
-					if realPool.Properties.OutboundRule != nil {
-						loadBalancerBackendAddressPoolsArgument = nil
-						attachedOutboundRule = realPool.Properties.OutboundRule
-						break OuterLoop
-					}
-					if realPool.Properties.OutboundRules != nil && len(realPool.Properties.OutboundRules) > 0 {
-						loadBalancerBackendAddressPoolsArgument = nil
-						attachedOutboundRule = (realPool.Properties.OutboundRules)[0]
-						break OuterLoop
-					}
-				}
-			}
-		}
-	}
-	if loadBalancerBackendAddressPoolsArgument == nil {
-		outboundRuleStr := ""
-		if attachedOutboundRule != nil && attachedOutboundRule.ID != nil {
-			// https://issues.redhat.com/browse/OCPBUGS-33617 showed that there can be a rule without an ID...
-			outboundRuleStr = fmt.Sprintf(": %s", ptr.Deref(attachedOutboundRule.ID, ""))
-		}
-		klog.Warningf("Egress IP %s will have no outbound connectivity except for the infrastructure subnet: "+
-			"omitting backend address pool when adding secondary IP: it has an outbound rule already%s",
-			ipc, outboundRuleStr)
-	}
 	newIPConfiguration := &armnetwork.InterfaceIPConfiguration{
 		Name: &name,
 		Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
-			PrivateIPAddress:                &ipc,
-			PrivateIPAllocationMethod:       ptr.To(armnetwork.IPAllocationMethodStatic),
-			Subnet:                          networkInterface.Properties.IPConfigurations[0].Properties.Subnet,
-			Primary:                         &untrue,
-			LoadBalancerBackendAddressPools: loadBalancerBackendAddressPoolsArgument,
-			ApplicationSecurityGroups:       applicationSecurityGroups,
+			PrivateIPAddress:          &ipc,
+			PrivateIPAllocationMethod: ptr.To(armnetwork.IPAllocationMethodStatic),
+			Subnet:                    networkInterface.Properties.IPConfigurations[0].Properties.Subnet,
+			Primary:                   ptr.To(false),
+			ApplicationSecurityGroups: applicationSecurityGroups,
 		},
 	}
 	for _, ipCfg := range ipConfigurations {
@@ -488,46 +437,6 @@ func (a *Azure) getNetworkInterfaces(instance *armcompute.VirtualMachine) ([]arm
 		return nil, NoNetworkInterfaceError
 	}
 	return networkInterfaces, nil
-}
-
-func splitObjectID(azureResourceID string) (resourceGroupName, loadBalancerName, backendAddressPoolName string) {
-	// example of an azureResourceID:
-	// "/subscriptions/53b8f551-f0fc-4bea-8cba-6d1fefd54c8a/resourceGroups/huirwang-debug1-2qh9t-rg/providers/Microsoft.Network/loadBalancers/huirwang-debug1-2qh9t/backendAddressPools/huirwang-debug1-2qh9t"
-
-	// Split the Azure resource ID into parts using "/"
-	parts := strings.Split(azureResourceID, "/")
-
-	// Iterate through the parts to find the relevant subIDs
-	for i, part := range parts {
-		switch part {
-		case "resourceGroups":
-			if i+1 < len(parts) {
-				resourceGroupName = parts[i+1]
-			}
-		case "loadBalancers":
-			if i+1 < len(parts) {
-				loadBalancerName = parts[i+1]
-			}
-		case "backendAddressPools":
-			if i+1 < len(parts) {
-				backendAddressPoolName = parts[i+1]
-			}
-		}
-	}
-	return
-}
-
-func (a *Azure) getBackendAddressPool(poolID string) (*armnetwork.BackendAddressPool, error) {
-	ctx, cancel := context.WithTimeout(a.ctx, defaultAzureOperationTimeout)
-	defer cancel()
-	resourceGroupName, loadBalancerName, backendAddressPoolName := splitObjectID(poolID)
-	response, err := a.backendAddressPoolClient.Get(ctx, resourceGroupName, loadBalancerName, backendAddressPoolName, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve backend address pool for backendAddressPoolClient=%s, loadBalancerName=%s, backendAddressPoolName=%s: %w",
-			resourceGroupName, loadBalancerName, backendAddressPoolName, err)
-	}
-	return &response.BackendAddressPool, nil
-
 }
 
 func (a *Azure) getNetworkInterface(id string) (armnetwork.Interface, error) {

--- a/pkg/cloudprovider/azure_test.go
+++ b/pkg/cloudprovider/azure_test.go
@@ -1,0 +1,365 @@
+package cloudprovider
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v6"
+	"github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+)
+
+func Test_updateNICIPConfigurations(t *testing.T) {
+	testIP := "127.0.0.2"
+
+	primaryASGs := []*armnetwork.ApplicationSecurityGroup{
+		{ID: ptr.To("primary-asg-id")},
+	}
+	primarySubnet := armnetwork.Subnet{
+		ID: ptr.To("primary-subnet-id"),
+	}
+	primaryLoadBalancerAddressPools := []*armnetwork.BackendAddressPool{
+		{ID: ptr.To("primary-lb-addresspool-id")},
+	}
+
+	// primaryIPConfiguration is the primary IPConfiguration of the NIC
+	primaryIPConfiguration := armnetwork.InterfaceIPConfiguration{
+		ID:   ptr.To("primary-id"),
+		Name: ptr.To("primary-name"),
+		Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+			ApplicationSecurityGroups:       primaryASGs,
+			LoadBalancerBackendAddressPools: primaryLoadBalancerAddressPools,
+			Primary:                         ptr.To(true),
+			PrivateIPAddress:                ptr.To("127.0.0.1"),
+			PrivateIPAllocationMethod:       ptr.To(armnetwork.IPAllocationMethodDynamic),
+			Subnet:                          &primarySubnet,
+		},
+		Type: ptr.To("primary-type"),
+		Etag: ptr.To("primary-etag"),
+	}
+
+	// testIPGenerated is the IPConfiguration generated for the testIP. It does not contain fields which are only returned by the server.
+	testIPGenerated := armnetwork.InterfaceIPConfiguration{
+		Name: ptr.To("test-node_127.0.0.2"),
+		Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+			PrivateIPAddress:          &testIP,
+			ApplicationSecurityGroups: primaryASGs,
+			Primary:                   ptr.To(false),
+			PrivateIPAllocationMethod: ptr.To(armnetwork.IPAllocationMethodStatic),
+			Subnet:                    &primarySubnet,
+		},
+	}
+
+	// testIPMatch is an additional IPConfiguration with the test IP which matches the desired state
+	testIPMatch := armnetwork.InterfaceIPConfiguration{
+		ID:   ptr.To("testipmatch-id"),
+		Name: ptr.To("test-node_127.0.0.2"),
+		Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+			PrivateIPAddress:          &testIP,
+			ApplicationSecurityGroups: primaryASGs,
+			Primary:                   ptr.To(false),
+			PrivateIPAllocationMethod: ptr.To(armnetwork.IPAllocationMethodStatic),
+			Subnet:                    &primarySubnet,
+		},
+		Type: ptr.To("testipmatch-type"),
+		Etag: ptr.To("testipmatch-etag"),
+	}
+	// testIPNoMatch is an additional IPConfiguration with the test IP which does not match the desired state
+	testIPNoMatch := armnetwork.InterfaceIPConfiguration{
+		ID:   ptr.To("testipnomatch-id"),
+		Name: ptr.To("test-node_127.0.0.2"),
+		Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+			PrivateIPAddress:                &testIP,
+			ApplicationSecurityGroups:       primaryASGs,
+			LoadBalancerBackendAddressPools: primaryLoadBalancerAddressPools,
+			Primary:                         ptr.To(false),
+			PrivateIPAllocationMethod:       ptr.To(armnetwork.IPAllocationMethodStatic),
+			Subnet:                          &primarySubnet,
+		},
+		Type: ptr.To("testipnomatch-type"),
+		Etag: ptr.To("testipnomatch-etag"),
+	}
+
+	// altIP is an additional IPConfiguration which does not have the test IP
+	altIP := armnetwork.InterfaceIPConfiguration{
+		ID:   ptr.To("altip-id"),
+		Name: ptr.To("altip-name"),
+		Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+			PrivateIPAddress:          ptr.To("127.0.0.2"),
+			Primary:                   ptr.To(false),
+			PrivateIPAllocationMethod: ptr.To(armnetwork.IPAllocationMethodStatic),
+			Subnet:                    &primarySubnet,
+		},
+		Type: ptr.To("altip-type"),
+		Etag: ptr.To("altip-etag"),
+	}
+
+	type args struct {
+		ipConfigurations []*armnetwork.InterfaceIPConfiguration
+	}
+	tests := []struct {
+		name          string
+		args          args
+		wantIPConfigs []*armnetwork.InterfaceIPConfiguration
+		wantErr       bool
+	}{
+		{
+			name: "should add egress ip when there are none",
+			args: args{
+				ipConfigurations: []*armnetwork.InterfaceIPConfiguration{
+					&primaryIPConfiguration,
+				},
+			},
+			wantIPConfigs: []*armnetwork.InterfaceIPConfiguration{
+				&primaryIPConfiguration,
+				&testIPGenerated,
+			},
+			wantErr: false,
+		},
+		{
+			name: "should not add egress ip when defined and up to date",
+			args: args{
+				ipConfigurations: []*armnetwork.InterfaceIPConfiguration{
+					&primaryIPConfiguration,
+					&testIPMatch,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "should update egress ip when defined but not up to date",
+			args: args{
+				ipConfigurations: []*armnetwork.InterfaceIPConfiguration{
+					&primaryIPConfiguration,
+					&testIPNoMatch,
+				},
+			},
+			wantIPConfigs: []*armnetwork.InterfaceIPConfiguration{
+				&primaryIPConfiguration,
+				&testIPGenerated,
+			},
+			wantErr: false,
+		},
+		{
+			name: "should update egress ip in place when defined but not up to date",
+			args: args{
+				ipConfigurations: []*armnetwork.InterfaceIPConfiguration{
+					&primaryIPConfiguration,
+					&testIPNoMatch,
+					&altIP,
+				},
+			},
+			wantIPConfigs: []*armnetwork.InterfaceIPConfiguration{
+				&primaryIPConfiguration,
+				&testIPGenerated,
+				&altIP,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+
+			nicProperties := &armnetwork.InterfacePropertiesFormat{
+				IPConfigurations: tt.args.ipConfigurations,
+			}
+
+			err := updateNICIPConfigurations(testIP, "test-node", nicProperties)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("updateNICIPConfigurations() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if err == nil {
+				g.Expect(nicProperties.IPConfigurations).To(gomega.Equal(tt.wantIPConfigs), "IPConfigurations")
+			}
+		})
+	}
+}
+
+func Test_ipconfigMatches(t *testing.T) {
+	// baseIPConfiguration returns an IPConfiguration with basic input fields set to test values
+	baseIPConfiguration := func() *armnetwork.InterfaceIPConfiguration {
+		return &armnetwork.InterfaceIPConfiguration{
+			Name: ptr.To("test-name"),
+			Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+				ApplicationSecurityGroups: []*armnetwork.ApplicationSecurityGroup{
+					{ID: ptr.To("asg-id")},
+				},
+				Primary:                   ptr.To(false),
+				PrivateIPAddress:          ptr.To("127.0.0.1"),
+				PrivateIPAllocationMethod: ptr.To(armnetwork.IPAllocationMethodStatic),
+				Subnet: &armnetwork.Subnet{
+					ID: ptr.To("test-subnet-id"),
+				},
+			},
+		}
+	}
+
+	// populatedBaseIPConfiguration returns an IPConfiguration with the same
+	// fields set as baseIPConfiguration, but with additional values set which
+	// would have been populated when returned in an API response
+	populatedBaseIPConfiguration := func() *armnetwork.InterfaceIPConfiguration {
+		ipConfiguration := baseIPConfiguration()
+
+		ipConfiguration.ID = ptr.To("test-id")
+		ipConfiguration.Etag = ptr.To("test-etag")
+		ipConfiguration.Properties.ProvisioningState = ptr.To(armnetwork.ProvisioningStateSucceeded)
+		ipConfiguration.Properties.ApplicationSecurityGroups[0].Etag = ptr.To("asg-etag")
+		ipConfiguration.Properties.ApplicationSecurityGroups[0].Properties = &armnetwork.ApplicationSecurityGroupPropertiesFormat{
+			ProvisioningState: ptr.To(armnetwork.ProvisioningStateSucceeded),
+			ResourceGUID:      ptr.To("asg-guid"),
+		}
+		ipConfiguration.Properties.Subnet.Name = ptr.To("subnet-name")
+		ipConfiguration.Properties.Subnet.Etag = ptr.To("subnet-etag")
+		ipConfiguration.Properties.Subnet.Properties = &armnetwork.SubnetPropertiesFormat{
+			ProvisioningState: ptr.To(armnetwork.ProvisioningStateSucceeded),
+		}
+
+		return ipConfiguration
+	}
+
+	type args struct {
+		current func() *armnetwork.InterfaceIPConfiguration
+		desired func() *armnetwork.InterfaceIPConfiguration
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "identical base fields",
+			args: args{
+				current: populatedBaseIPConfiguration,
+				desired: baseIPConfiguration,
+			},
+			want: true,
+		},
+		{
+			name: "private IP allocation method differs should not match",
+			args: args{
+				current: func() *armnetwork.InterfaceIPConfiguration {
+					ipConfig := populatedBaseIPConfiguration()
+					ipConfig.Properties.PrivateIPAllocationMethod = ptr.To(armnetwork.IPAllocationMethodDynamic)
+					return ipConfig
+				},
+				desired: baseIPConfiguration,
+			},
+			want: false,
+		},
+		{
+			name: "primary differs should not match",
+			args: args{
+				current: func() *armnetwork.InterfaceIPConfiguration {
+					ipConfig := populatedBaseIPConfiguration()
+					ipConfig.Properties.Primary = ptr.To(true)
+					return ipConfig
+				},
+				desired: baseIPConfiguration,
+			},
+			want: false,
+		},
+		{
+			name: "subnet differs should not match",
+			args: args{
+				current: func() *armnetwork.InterfaceIPConfiguration {
+					ipConfig := populatedBaseIPConfiguration()
+					ipConfig.Properties.Subnet.ID = ptr.To("subnet-id-alt")
+					return ipConfig
+				},
+				desired: baseIPConfiguration,
+			},
+			want: false,
+		},
+		{
+			name: "egress IP has LoadBalancerBackendAddressPools should not match",
+			args: args{
+				current: func() *armnetwork.InterfaceIPConfiguration {
+					ipConfig := populatedBaseIPConfiguration()
+					ipConfig.Properties.LoadBalancerBackendAddressPools = []*armnetwork.BackendAddressPool{
+						{
+							ID:         ptr.To("lb-pool-id"),
+							Name:       ptr.To("lb-pool-name"),
+							Properties: &armnetwork.BackendAddressPoolPropertiesFormat{},
+							Etag:       ptr.To("lb-pool-etag"),
+						},
+					}
+					return ipConfig
+				},
+				desired: baseIPConfiguration,
+			},
+			want: false,
+		},
+		{
+			name: "extra application security group should not match",
+			args: args{
+				current: func() *armnetwork.InterfaceIPConfiguration {
+					ipConfig := populatedBaseIPConfiguration()
+					ipConfig.Properties.ApplicationSecurityGroups = append(ipConfig.Properties.ApplicationSecurityGroups, &armnetwork.ApplicationSecurityGroup{
+						ID: ptr.To("asg-id-alt"),
+					})
+					return ipConfig
+				},
+				desired: baseIPConfiguration,
+			},
+			want: false,
+		},
+		{
+			name: "missing application security group should not match",
+			args: args{
+				current: func() *armnetwork.InterfaceIPConfiguration {
+					ipConfig := populatedBaseIPConfiguration()
+					ipConfig.Properties.ApplicationSecurityGroups = nil
+					return ipConfig
+				},
+				desired: baseIPConfiguration,
+			},
+			want: false,
+		},
+		{
+			name: "multiple application security groups differ by one should not match",
+			args: args{
+				current: func() *armnetwork.InterfaceIPConfiguration {
+					ipConfig := populatedBaseIPConfiguration()
+					ipConfig.Properties.ApplicationSecurityGroups = append(ipConfig.Properties.ApplicationSecurityGroups, &armnetwork.ApplicationSecurityGroup{
+						ID: ptr.To("asg-id-alt"),
+					})
+					return ipConfig
+				},
+				desired: func() *armnetwork.InterfaceIPConfiguration {
+					ipConfig := populatedBaseIPConfiguration()
+					ipConfig.Properties.ApplicationSecurityGroups = append(ipConfig.Properties.ApplicationSecurityGroups, &armnetwork.ApplicationSecurityGroup{
+						ID: ptr.To("asg-id-alt2"),
+					})
+					return ipConfig
+				},
+			},
+			want: false,
+		},
+		{
+			name: "same application security groups in different order should match",
+			args: args{
+				current: func() *armnetwork.InterfaceIPConfiguration {
+					ipConfig := populatedBaseIPConfiguration()
+					ipConfig.Properties.ApplicationSecurityGroups = append(ipConfig.Properties.ApplicationSecurityGroups, &armnetwork.ApplicationSecurityGroup{
+						ID: ptr.To("asg-id-alt"),
+					})
+					return ipConfig
+				},
+				desired: func() *armnetwork.InterfaceIPConfiguration {
+					ipConfig := populatedBaseIPConfiguration()
+					ipConfig.Properties.ApplicationSecurityGroups = append([]*armnetwork.ApplicationSecurityGroup{{ID: ptr.To("asg-id-alt")}}, ipConfig.Properties.ApplicationSecurityGroups...)
+					return ipConfig
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ipconfigMatches(tt.args.current(), tt.args.desired()); got != tt.want {
+				t.Errorf("ipconfigMatches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**DO NOT MERGE**

This solution assumes that the lack of external connectivity for EgressIPs is a known limitation and therefore deliberately makes no attempt to preserve it. However, it turns out this is a regression rather than a known limitation, and one that only affects clusters installed since the regression was introduced. Therefore by removing external connectivity in all cases, this PR would itself cause a regression for users who were not otherwise affected by it because they had upgraded from an unaffected version.

See https://issues.redhat.com/browse/OCPBUGS-57422 for discussion of the regression.

Leaving it open for now, but I (@mdbooth) expect to close this without merging.

---
With this change we no longer set LoadBalancerBackendAddressPools on IPConfigurations associated with an EgressIP. We do this for 2 reasons:
* We do not require the LoadBalancer to direct traffic to the EgressIP for inbound traffic.
* Adding these rules multiplies the number of loadbalancer rules on a NIC by the number of Egress IPs assigned to that NIC

The latter will prevent the addition of new EgressIPs and LoadBalancer services which can be added to the whole cluster once any NIC in the cluster exceeds 300 rules.

**NOTE**: Egress IPs were previously already excluded from any LoadBalancerBackendAddressPool with an outbound rule. This means that any pod matched by an Egress IP was *already prevented from making outbound connections*. This change was made in https://github.com/openshift/cloud-network-config-controller/pull/121. There is currently no solution to this issue, except possibly using a NAT gateway instead.

The snyk changes are unrelated, but required to get `test-security` to pass.