### PR TITLE
OCPBUGS-65567: [release-4.16] Change the capacity struct from int to ptrOfInt

### DIFF
--- a/pkg/cloudprovider/aws.go
+++ b/pkg/cloudprovider/aws.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -218,8 +219,9 @@ func (a *AWS) GetNodeEgressIPConfiguration(node *corev1.Node, cloudPrivateIPConf
 		return nil, err
 	}
 	config.Capacity = capacity{
-		IPv4: capV4,
-		IPv6: capV6,
+		IPv4: ptr.To(capV4),
+		IPv6: ptr.To(capV6),
+		// IP field not used by AWS (uses per-IP-family capacity)
 	}
 	return []*NodeEgressIPConfiguration{config}, nil
 }

--- a/pkg/cloudprovider/azure.go
+++ b/pkg/cloudprovider/azure.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -310,7 +311,8 @@ func (a *Azure) GetNodeEgressIPConfiguration(node *corev1.Node, cloudPrivateIPCo
 		config.IFAddr.IPv6 = v6Subnet.String()
 	}
 	config.Capacity = capacity{
-		IP: a.getCapacity(networkInterface, len(cloudPrivateIPConfigs)),
+		// IPv4 and IPv6 fields not used by Azure (uses IP-family-agnostic capacity)
+		IP: ptr.To(a.getCapacity(networkInterface, len(cloudPrivateIPConfigs))),
 	}
 	return []*NodeEgressIPConfiguration{config}, nil
 }

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -101,9 +101,9 @@ type ifAddr struct {
 }
 
 type capacity struct {
-	IPv4 int `json:"ipv4,omitempty"`
-	IPv6 int `json:"ipv6,omitempty"`
-	IP   int `json:"ip,omitempty"`
+	IPv4 *int `json:"ipv4,omitempty"`
+	IPv6 *int `json:"ipv6,omitempty"`
+	IP   *int `json:"ip,omitempty"`
 }
 
 //  NodeEgressIPConfiguration stores details - specific to each cloud - which are

--- a/pkg/cloudprovider/gcp.go
+++ b/pkg/cloudprovider/gcp.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/api/option"
 	corev1 "k8s.io/api/core/v1"
 	utilnet "k8s.io/utils/net"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -182,7 +183,8 @@ func (g *GCP) GetNodeEgressIPConfiguration(node *corev1.Node, cloudPrivateIPConf
 			config.IFAddr.IPv6 = v6Subnet.String()
 		}
 		config.Capacity = capacity{
-			IP: g.getCapacity(networkInterface, len(cloudPrivateIPConfigs)),
+			// IPv4 and IPv6 fields not used by GCP (uses IP-family-agnostic capacity)
+			IP: ptr.To(g.getCapacity(networkInterface, len(cloudPrivateIPConfigs))),
 		}
 		return []*NodeEgressIPConfiguration{config}, nil //nolint:staticcheck
 	}

--- a/pkg/cloudprovider/openstack.go
+++ b/pkg/cloudprovider/openstack.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -592,7 +593,8 @@ func (o *OpenStack) getNeutronPortNodeEgressIPConfiguration(p neutronports.Port,
 			IPv6: ipv6,
 		},
 		Capacity: capacity{
-			IP: c,
+			// IPv4 and IPv6 fields not used by OpenStack (uses IP-family-agnostic capacity)
+			IP: ptr.To(c),
 		},
 	}, nil
 }

--- a/pkg/cloudprovider/openstack_test.go
+++ b/pkg/cloudprovider/openstack_test.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -675,7 +676,7 @@ func TestOpenStackPlugin(t *testing.T) {
 				IPv6: "2000::/64",
 			},
 			Capacity: capacity{
-				IP: openstackMaxCapacity,
+				IP: ptr.To(openstackMaxCapacity),
 			},
 		},
 	}
@@ -802,7 +803,7 @@ func TestGetNodeEgressIPConfiguration(t *testing.T) {
 							IPv6: "2000::/64",
 						},
 						Capacity: capacity{
-							IP: openstackMaxCapacity,
+							IP: ptr.To(openstackMaxCapacity),
 						},
 					},
 				},
@@ -838,7 +839,7 @@ func TestGetNodeEgressIPConfiguration(t *testing.T) {
 							IPv6: "2001::/64",
 						},
 						Capacity: capacity{
-							IP: openstackMaxCapacity,
+							IP: ptr.To(openstackMaxCapacity),
 						},
 					},
 				},
@@ -882,7 +883,7 @@ func TestGetNodeEgressIPConfiguration(t *testing.T) {
 							IPv6: "2000::/64",
 						},
 						Capacity: capacity{
-							IP: openstackMaxCapacity,
+							IP: ptr.To(openstackMaxCapacity),
 						},
 					},
 				},
@@ -929,7 +930,7 @@ func TestGetNodeEgressIPConfiguration(t *testing.T) {
 							IPv6: "2000::/64",
 						},
 						Capacity: capacity{
-							IP: openstackMaxCapacity,
+							IP: ptr.To(openstackMaxCapacity),
 						},
 					},
 				},
@@ -941,7 +942,7 @@ func TestGetNodeEgressIPConfiguration(t *testing.T) {
 							IPv6: "2001::/64",
 						},
 						Capacity: capacity{
-							IP: openstackMaxCapacity,
+							IP: ptr.To(openstackMaxCapacity),
 						},
 					},
 				},
@@ -1026,7 +1027,7 @@ func TestGetNeutronPortNodeEgressIPConfiguration(t *testing.T) {
 					IPv6: "2000::/64",
 				},
 				Capacity: capacity{
-					IP: openstackMaxCapacity - 2, // 2 allowed_address_pairs configured on the port.
+					IP: ptr.To(openstackMaxCapacity - 2), // 2 allowed_address_pairs configured on the port.
 				},
 			},
 		},
@@ -1039,7 +1040,7 @@ func TestGetNeutronPortNodeEgressIPConfiguration(t *testing.T) {
 					IPv6: "2000::/64",
 				},
 				Capacity: capacity{
-					IP: openstackMaxCapacity + 3 - 2, // excluding 2 allowed_address_pairs configured on the port.
+					IP: ptr.To(openstackMaxCapacity + 3 - 2), // excluding 2 allowed_address_pairs configured on the port.
 				},
 			},
 			// Configure cloudPrivateIPConfigs with 3 ips are within neutron subnet, 1 ip outside neutron subnet.


### PR DESCRIPTION
Manual cherry-pick of 24443ba0813bd0fe8dc533cabb08f6ea315b2869.
Minor conflicts in: `pkg/cloudprovider/cloudprovider.go`