### PR TITLE
OCPBUGS-74496: Add UserAgent to Azure SDK client telemetry options

### DIFF
--- a/pkg/cloudprovider/azure.go
+++ b/pkg/cloudprovider/azure.go
@@ -150,6 +150,9 @@ func (a *Azure) initCredentials() error {
 	options := &arm.ClientOptions{
 		ClientOptions: policy.ClientOptions{
 			Cloud: cloudConfig,
+			Telemetry: policy.TelemetryOptions{
+				ApplicationID: UserAgent,
+			},
 		},
 	}
 
@@ -593,6 +596,9 @@ func (a *Azure) getAzureCredentials(env azureapi.Environment, cfg *azureCredenti
 		klog.Infof("Using user assigned identity credentials authentication")
 		clientOptions := azcore.ClientOptions{
 			Cloud: cloudConfig,
+			Telemetry: policy.TelemetryOptions{
+				ApplicationID: UserAgent,
+			},
 		}
 		cred, err = dataplane.NewUserAssignedIdentityCredential(context.Background(), userAssignedIdentityCredentialsFilePath, dataplane.WithClientOpts(clientOptions))
 		if err != nil {
@@ -607,6 +613,9 @@ func (a *Azure) getAzureCredentials(env azureapi.Environment, cfg *azureCredenti
 			options := azidentity.WorkloadIdentityCredentialOptions{
 				ClientOptions: azcore.ClientOptions{
 					Cloud: cloudConfig,
+					Telemetry: policy.TelemetryOptions{
+						ApplicationID: UserAgent,
+					},
 				},
 				ClientID:      cfg.clientID,
 				TenantID:      cfg.tenantID,
@@ -625,6 +634,9 @@ func (a *Azure) getAzureCredentials(env azureapi.Environment, cfg *azureCredenti
 		options := azidentity.ClientSecretCredentialOptions{
 			ClientOptions: azcore.ClientOptions{
 				Cloud: cloudConfig,
+				Telemetry: policy.TelemetryOptions{
+					ApplicationID: UserAgent,
+				},
 			},
 		}
 		cred, err = azidentity.NewClientSecretCredential(cfg.tenantID, cfg.clientID, cfg.clientSecret, &options)


### PR DESCRIPTION
## What this PR does / why we need it

The Cloud Network Config Controller (CNCC) is not setting the ApplicationID in the Azure SDK TelemetryOptions when creating Azure ARM SDK clients and credential clients. This means Azure
API requests from CNCC do not include proper application identification in the User-Agent header for request tracing and telemetry purposes.

Note: the `UserAgent` constant is already defined in the codebase (`cloud-network-config-controller`) but was only applied to GCP clients, not Azure clients.

This PR adds `policy.TelemetryOptions` with `ApplicationID` to:
- ARM clients (`VirtualMachinesClient`, `InterfacesClient`, `VirtualNetworksClient`)
- Azure credential clients (`UserAssignedIdentityCredential`, `WorkloadIdentityCredential`, `ClientSecretCredential`)

## Which issue(s) this PR fixes

Fixes https://issues.redhat.com/browse/OCPBUGS-74496

## Special notes for your reviewer

- The `UserAgent` constant value is `cloud-network-config-controller` (31 characters), but the Azure SDK enforces a maximum of 24 characters with no spaces for `ApplicationID` and silently truncates it to `cloud-network-config-con`. This has been flagged in the Jira issue for discussion.

## Checklist

- [x] Subject and description added to both the commit and PR
- [x] Relevant issues referenced
- [ ] Unit tests included