### PR TITLE
CORENET-7297: Add CodeRabbit AI review configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# Inherit settings from the organization-level .coderabbit.yaml configuration.
+inheritance: true
+reviews:
+  instructions: >-
+    This is the cloud-network-config-controller (CNCC). It is an OpenShift
+    controller/operator that interfaces with cloud provider APIs (AWS, Azure, GCP,
+    OpenStack) to manage private IP address assignments on VM instances associated
+    with Kubernetes nodes. It manages the CloudPrivateIPConfig CRD
+    (cloud.network.openshift.io/v1) and annotates node objects with egress IP
+    capacity and subnet information. Reviews should consider: multi-cloud provider
+    correctness (AWS, Azure, GCP, OpenStack), credential handling and rotation
+    safety, atomic add/delete control loop semantics, finalizer correctness,
+    backward compatibility, upgrade safety, and IPv4/IPv6 dual-stack support.
+  high_level_summary: true
+  high_level_summary_in_walkthrough: true
+  poem: false
+  path_instructions:
+    - path: '**'
+      instructions: |
+        - Focus on major issues impacting performance, readability, maintainability and security.
+        - Avoid nitpicks and avoid verbosity.
+  path_filters:
+    - "!vendor/**"
+    - "!_output/**"
+  auto_review:
+    drafts: false
+    ignore_title_keywords:
+      - WIP
+      - DNM
+    # To exclude labels, be sure to negate the label with '!'.
+    # Non-negated values turn this into an allowlist.
+    labels:
+      - '!work-in-progress'
+  slop_detection:
+    enabled: true
+    label: "coderabbit/ai-slop"


### PR DESCRIPTION
Configure CodeRabbit for automated PR reviews tailored to the CNCC, with instructions covering multi-cloud correctness, credential handling, atomic control loop semantics, and dual-stack support.

See https://github.com/openshift/cluster-network-operator/pull/3023#issuecomment-4740241977 for org level context
See https://docs.google.com/document/d/1LdyFK6nqH2ZovXc4Q9Hvf7v4B5ujzhi8DgzeOFcX_QE/edit?tab=t.0 for repo level instructions

Since we have inheritance set to true, we will inherit everything at org level.
This is just the beginning, I will do two more follow up PRs for

1. custom checks/pre-merge-checks and
2. path-specific review instructions along with adding more global instructions

moving forward we need to be adding E2E's and developer docs in CNCC itself for every PR - its not going to be acceptable to let QE folks add them later since all that process has now changed.