### PR TITLE
OCPBUGS-64575: Refresh egress IP capacity annotation on informer resync

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -78,11 +78,20 @@ func NewNodeController(
 	_, err := nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: controller.Enqueue,
 		UpdateFunc: func(oldN, newN interface{}) {
+			oldNode, _ := oldN.(*corev1.Node)
+			newNode, _ := newN.(*corev1.Node)
+			// Enqueue on informer resync (same ResourceVersion means the object hasn't changed
+			// in the API server — the informer is just re-delivering the cached object).
+			// This ensures SyncHandler periodically re-queries the cloud API for current
+			// capacity, keeping the egress-ipconfig annotation up to date as IPs are
+			// assigned or released.
+			if oldNode.ResourceVersion == newNode.ResourceVersion {
+				controller.Enqueue(newN)
+				return
+			}
 			// Enqueue when an update to the node's taints occurred - for external cloud providers, we must
 			// catch changes to taint node.cloudprovider.kubernetes.io/uninitialized.
 			// See https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/
-			oldNode, _ := oldN.(*corev1.Node)
-			newNode, _ := newN.(*corev1.Node)
 			if !reflect.DeepEqual(oldNode.Spec.Taints, newNode.Spec.Taints) {
 				controller.Enqueue(newN)
 			}


### PR DESCRIPTION
## Summary
- The node controller's `UpdateFunc` only enqueued nodes on taint changes, causing `SyncHandler` to run only once at node add time
- The 2-minute informer resync events were silently dropped because `old==new` means taints never differ
- This left the `cloud.network.openshift.io/egress-ipconfig` annotation stale — capacity never updated as EgressIPs were assigned or released
- Fix: detect resync events (same `ResourceVersion`) and enqueue the node so `SyncHandler` re-queries the cloud API with current CPIC state

## Root Cause
When an EgressIP is assigned, CNCC adds the IP to the cloud ENI via `CloudPrivateIPConfig`, but never recalculates the node's capacity annotation. The `getCapacity()` function correctly excludes CPIC-managed IPs, but it's only called from `SyncHandler`, which only ran at node add time (when no CPICs existed yet). This meant all IPs on the ENI — including later-assigned EgressIPs — were counted as "non-CPIC" in the stale annotation, double-reducing available capacity.

## Test plan
- [ ] Deploy on AWS cluster with EgressIP configured
- [ ] Verify capacity annotation updates automatically every ~2 minutes without CNCC pod restart
- [ ] Assign an EgressIP and confirm capacity annotation reflects correct CPIC-excluded count
- [ ] Remove the EgressIP and confirm capacity annotation updates accordingly
- [ ] Verify no excessive AWS API calls beyond the 2-minute resync interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)