### PR TITLE
DNM: log first IPv6 CIDR association entry for debugging

### DIFF
--- a/pkg/cloudprovider/aws.go
+++ b/pkg/cloudprovider/aws.go
@@ -287,6 +287,12 @@ func (a *AWS) getSubnet(networkInterface *ec2.InstanceNetworkInterface) (*net.IP
 	// one subnet, specially given that you can only have one IPv4 CIDR block
 	// defined...¯\_(ツ)_/¯
 	// Let's just pick the first.
+	if len(subnet.Ipv6CidrBlockAssociationSet) > 0 {
+		klog.Infof("getSubnet: subnet %s first IPv6 CIDR association: cidr=%s state=%s",
+			awsapi.StringValue(networkInterface.SubnetId),
+			awsapi.StringValue(subnet.Ipv6CidrBlockAssociationSet[0].Ipv6CidrBlock),
+			awsapi.StringValue(subnet.Ipv6CidrBlockAssociationSet[0].Ipv6CidrBlockState.State))
+	}
 	if len(subnet.Ipv6CidrBlockAssociationSet) > 0 && subnet.Ipv6CidrBlockAssociationSet[0].Ipv6CidrBlock != nil && *subnet.Ipv6CidrBlockAssociationSet[0].Ipv6CidrBlock != "" {
 		_, subnet, err := net.ParseCIDR(*subnet.Ipv6CidrBlockAssociationSet[0].Ipv6CidrBlock)
 		if err != nil {


### PR DESCRIPTION
## Summary

This is a **Do Not Merge** experimental PR for diagnostic purposes only.

Adds a temporary `klog.Infof` in `getSubnet` to log the first entry in `Ipv6CidrBlockAssociationSet` (CIDR value and its state) before the existing code uses it. This allows us to observe whether the old code was picking a stale `disassociated` entry — answering the reviewer question on #228 about what the incorrect subnet value actually was.

## How to use

Deploy this build on a dualstack cluster whose subnet has a stale IPv6 CIDR association, then check the CNCC pod logs:

```bash
oc logs -n openshift-cloud-network-config-controller \
  deployment/cloud-network-config-controller -f | grep getSubnet
```

Expected output (on affected cluster):
```
getSubnet: subnet subnet-0abc123 first IPv6 CIDR association: cidr=<stale-cidr>/64 state=disassociated
```

## Related

- #228

Made with [Cursor](https://cursor.com)